### PR TITLE
add menu prototype

### DIFF
--- a/css/cyber.css
+++ b/css/cyber.css
@@ -19,9 +19,9 @@
 
 
 body {
-	margin:0;
+	margin: 60px 0 0 0;
 	color: #111;
-	background: #eee;
+	background: #F0F3F7;
 	font-size: 1em;
 	font-family: Arial, Helvetica, sans-serif;
 }
@@ -507,6 +507,63 @@ color: #555;
 text-decoration:none;
 }
 
+/* nav */
+
+nav {
+	position: fixed;
+	top: 0;
+	z-index: 20;
+	width: 100%;
+	height: 50px;
+	background: #DADEE5;
+	box-shadow: rgba(0, 0, 0, 0.28) 0 2px 1px;
+	font-size: 1.6em;
+	line-height: 50px;
+	font-weight: bold;
+}
+
+nav a {
+	margin: 0 10px;
+	text-decoration: none;
+}
+
+nav .logo {
+	position: fixed;
+	width: 150px;
+	margin-left: -75px;
+	left: 50%;
+	text-align: center;
+	letter-spacing: -1px;
+}
+
+nav .logo a {
+	margin: 0px;
+	color: #D1161F;
+}
+
+nav div a {
+	color: black;
+}
+
+nav .left, nav .right {
+	-moz-box-sizing: border-box;
+	-webkit-box-sizing: border-box;
+	box-sizing: border-box;
+	width: 50%;
+	font-size: 0.7em;
+}
+
+nav .left {
+	text-align: right;
+	padding: 0 80px 0 0;
+	float: left;
+}
+
+nav .right {
+	text-align: left;
+	padding: 0 0 0 80px;
+	float: right;
+}
 
 @media screen and (max-width: 950px){
     #shareside {

--- a/index.html
+++ b/index.html
@@ -22,6 +22,20 @@
 	</noscript>
 
 <div ids=overall>
+	<nav>
+		<div class="left">
+			<a href="#">What is Net Neutrality?</a>
+			<a href="#howtocall">HowTo</a>
+		</div>
+		<div class="right">
+			<a href="#learnmore">Learn about the Regulation</a>
+			<a href="#contact">Press / Contact</a>
+		</div>
+		<div class="logo">
+			<a href="#act">Take Action</a>
+		</div>
+	</nav>
+
 	<section id=langswitch>
 		<ul>
 			<li><a href="/en/"><b>EN</b></a></li>


### PR DESCRIPTION
Anmerkungen:
- Ich habe den default body background von `#eee` auf `#F0F3F7` gesetzt, damit ich dem body ein `margin-top` geben kann. Jetzt hat der untere Bereich der Seite eine leicht andere Hintergrundfarbe. Find ich eigentlich ganz schick und stimmig mit dem Beginn der Seite. Kann man aber auch separat anpassen.
- Mit der Reihenfolge der Links und genauer Benennung muss ggf. experimentiert werden. Wesentlich ist, dass links und rechts etwa gleich viele Text ist, sonst sieht es schief aus.
- Noch springen die Anker "zu weit". Das liegt daran, dass das Menü beim Springen nicht eingerechnet wird. Lösung: Anker von sichtbarem HTML separieren (`<span id="act" class="anchor"></span>`) und per CSS verschieben (`span.anchor {display: block; position: relative; top: -60px; visibility: hidden;}`)
