### PR TITLE
Langage non-sexiste

### DIFF
--- a/fr/index.html
+++ b/fr/index.html
@@ -3,7 +3,7 @@
 <html>
 
 <head>
-	<title>Sauvons Internet - contactez vos eurodéputés sans attendre&nbsp;!</title>
+	<title>Sauvons Internet - contactez vos eurodéputé·e·s sans attendre&nbsp;!</title>
 	<link rel="stylesheet" type="text/css" href="/css/cyber.css">
 	<meta http-equiv="content-type" content="text/html; charset=utf-8" charset="utf-8">
 	<meta name="description" content="Save the Internet in Europe">
@@ -25,7 +25,7 @@
 	<nav>
 		<div class="left">
 			<a href="#netneutrality">La neutralité du Net&nbsp;?</a>
-			<a href="#howtocall">Contacter un élu&nbsp;?</a>
+			<a href="#howtocall">Contacter un·e élu·e&nbsp;?</a>
 		</div>
 		<div class="right">
 			<a href="#learnmore">En savoir plus</a>
@@ -65,7 +65,7 @@
 				<section class=omgbuttonarea>
 					<a href="#act" class="omgbutton">
 						<img src="/img/phoneicon.png" class=vmid> 
-						<span class=vmid>Contactez vos eurodéputés sans attendre&nbsp;!</span>
+						<span class=vmid>Contactez vos eurodéputé·e·s sans attendre&nbsp;!</span>
 					</a>
 					<div id="orarrow_wrp"><div id=orarrow>POURQUOI&nbsp;?</div></div>
 				</section>
@@ -81,7 +81,7 @@
 					Vous pourriez avoir à payer des frais supplémentaires pour chaque service Internet
 				</h2></div>
 				<div class=desctext>
-					Un règlement proposé par la Commission européenne pourrait permettre aux fournisseurs d'accès à Internet (FAI) de faire payer des frais supplémentaires pour chaque service en ligne. Ce qu'ils appellent des «&nbsp;services spécialisés&nbsp;» pourrait conduire à un Internet à deux vitesses, où seules les entreprises en ayant les moyens pourraient bénéficier de la voie rapide, laissant tous les autres sur le carreau.
+					Un règlement proposé par la Commission européenne pourrait permettre aux fournisseurs d'accès à Internet (FAI) de faire payer des frais supplémentaires pour chaque service en ligne. Ce qu'ils appellent des «&nbsp;services spécialisés&nbsp;» pourrait conduire à un Internet à deux vitesses, où seules les entreprises en ayant les moyens pourraient bénéficier de la voie rapide, laissant tou·te·s les autres sur le carreau.
 				</div>
 				<div class=clr></div>
 				<div class=whypic id=whypic1><img id=whypicimg1 src="/img/specialized_services.png"></div>
@@ -164,7 +164,7 @@
             </a>
 						<b>Aide&nbsp;:</b><br>
 						&raquo; <a href="#learnmore">D'autres arguments</a><br>
-						&raquo; <a href="#howtocall">Comment contacter un eurodéputé&nbsp;?</a>
+						&raquo; <a href="#howtocall">Comment contacter un·e eurodéputé·e&nbsp;?</a>
 					</div>
 
 				</div>
@@ -198,7 +198,7 @@
 				<div class="moaromg">
 					<a href="#act" class="omgbutton">
 						<img src="/img/phoneicon.png" class=vmid> 
-						<span class=vmid>Appelez votre eurodéputé sans attendre&nbsp;! </span>
+						<span class=vmid>Appelez votre eurodéputé·e sans attendre&nbsp;! </span>
 					</a>
 				</div>
 			</div>
@@ -311,22 +311,22 @@
 		<div class=contentwidth>
 			<div class=indentarea2>
 
-				<h3>Comment contacter votre eurodéputé&nbsp;?</h3>
-				<p><b>Nous avons vaincu ACTA, et nous avons besoin de votre aide pour gagner cette nouvelle bataille. Agissez maintenant et appelez vos députés à protéger vos droits et vos libertés. La meilleure façon d'agir est de contacter directement un membre du Parlement européen. Mais vous pouvez aussi envoyer un fax, une lettre ou un email. Vous trouverez ici toutes les informations nécessaires – et les appels sont gratuits.</b></p>
+				<h3>Comment contacter votre eurodéputé·e&nbsp;?</h3>
+				<p><b>Nous avons vaincu ACTA, et nous avons besoin de votre aide pour gagner cette nouvelle bataille. Agissez maintenant et appelez vos député·e·s à protéger vos droits et vos libertés. La meilleure façon d'agir est de contacter directement un membre du Parlement européen. Mais vous pouvez aussi envoyer un fax, une lettre ou un email. Vous trouverez ici toutes les informations nécessaires – et les appels sont gratuits.</b></p>
 
 				<h4>Conseils généraux</h4>
 
 				<ul>
 					<li>Avant tout, informez-vous en <a href="#learnmore">lisant nos documents clés.</a></li>
-					<li>Soyez poli et restez vous-même. Quoi qu'il arrive, n'oubliez pas les règles élémentaires de politesse et de bon sens. Que vous soyez ou non d'accord avec votre interlocuteur, et quelles que soient les opinions des autres membres de son groupe politique, ne donnez pas une mauvaise image des personnes qui défendent la même cause que vous.</li>
-					<li>La plupart du temps, vous aurez au bout du fil un assistant parlementaire, et non directement un député. Ce n'est pas un problème. Engagez la conversation&nbsp;: les assistants jouent un rôle important dans la construction des positions des députés.</li>
-					<li>Si votre interlocuteur vous pose une question à laquelle vous ne pouvez pas répondre, ne paniquez pas. Personne n'attend de vous que vous soyez un expert&nbsp;: vous êtes simplement un citoyen inquiet. Dans ce cas, dites à votre interlocuteur que vous allez vous renseigner et le recontacterez avec la réponse. N'hésitez pas à nous demander de vous aider.</li>
-					<li>Si vous ne vous sentez toujours pas à l'aise avec les arguments, n'abandonnez pas&nbsp;! Demandez quelle est la position du député et quels sont ses arguments.</li>
-					<li>Lors de vos appels, n'hésitez pas à proposer de rappeler pour offrir plus d'informations, de proposer de rencontrer le député, d'envoyer des documents, des références… Parfois, les assistants vous demanderont d'envoyer un email. N'hésitez pas à rappeler un peu plus tard pour vous assurer qu'ils l'ont lu, et leur demander leur avis.</li>
+					<li>Soyez poli·e et restez vous-même. Quoi qu'il arrive, n'oubliez pas les règles élémentaires de politesse et de bon sens. Que vous soyez ou non d'accord avec votre interlocuteur/trice, et quelles que soient les opinions des autres membres de son groupe politique, ne donnez pas une mauvaise image des personnes qui défendent la même cause que vous.</li>
+					<li>La plupart du temps, vous aurez au bout du fil un·e assistant·e parlementaire, et non directement un·e député·e. Ce n'est pas un problème. Engagez la conversation&nbsp;: les assistant·e·s jouent un rôle important dans la construction des positions des députés.</li>
+					<li>Si votre interlocuteur/trice vous pose une question à laquelle vous ne pouvez pas répondre, ne paniquez pas. Personne n'attend de vous que vous soyez un·e expert·e&nbsp;: vous êtes simplement un·e citoyen·ne inquiet/ète. Dans ce cas, dites à votre interlocuteur/trice que vous allez vous renseigner et le/la recontacterez avec la réponse. N'hésitez pas à nous demander de vous aider.</li>
+					<li>Si vous ne vous sentez toujours pas à l'aise avec les arguments, n'abandonnez pas&nbsp;! Demandez quelle est la position de l’eurodéputé·e et quels sont ses arguments.</li>
+					<li>Lors de vos appels, n'hésitez pas à proposer de rappeler pour offrir plus d'informations, de proposer de rencontrer le/la député·e, d'envoyer des documents, des références… Parfois, les assistant·e·s vous demanderont d'envoyer un email. N'hésitez pas à rappeler un peu plus tard pour vous assurer qu'ils/elles l'ont lu, et leur demander leur avis.</li>
 				</ul>
 
 				<h4>Appel téléphonique</h4>
-				<p>La meilleure manière de faire passer votre message à un élu et de <b>développer vos arguments de vive voix</b>. De cette manière, vous pourrez adapter votre discours à ses réponses, et exprimer à quel point vous êtes concerné par le sujet en question. Les élus ne reçoivent pas beaucoup d'appels de citoyens, et y sont donc particulièrement sensibles. </p>
+				<p>La meilleure manière de faire passer votre message à un·e élu·e et de <b>développer vos arguments de vive voix</b>. De cette manière, vous pourrez adapter votre discours à ses réponses, et exprimer à quel point vous êtes concerné·e par le sujet en question. Les élu·e·s ne reçoivent pas beaucoup d'appels de citoyen·ne·s, et y sont donc particulièrement sensibles.</p>
 
 				<b>Généralement, les conversations se déroulent de cette manière&nbsp;:</b>
 				
@@ -334,21 +334,21 @@
 				<p>
 					<div class="ava-you">Vous</div> 
 					<div class="bubble-you">
-						Bonjour, je m'appelle [VotreNom], je suis un citoyen européen de [VotrePays], et je souhaiterais parler à Mme/M [NomDeL'élu(e)], s'il vous plaît.
+						Bonjour, je m'appelle [VotreNom], je suis un·e citoyen·ne européen·ne de [VotrePays], et je souhaiterais parler à Mme/M.&nbsp;[NomDeL'élu·e], s'il vous plaît.
 					</div>
 				</p>
 				<div class=clr></div>
 				<p>
 					<div class="ava-assistant">Assistant/e</div> 
 					<div class="bubble-assistant">
-						Mme/M [NomDeL'élu(e)] n'est pas disponible, je suis son assistant(e). En quoi puis-je vous aider&nbsp;?
+						Mme/M.&nbsp;[NomDeL'élu·e] n'est pas disponible, je suis son assistant·e. En quoi puis-je vous aider&nbsp;?
 					</div>
 				</p>
 				<div class=clr></div>
 				<p>
 					<div class="ava-you">Vous</div> 
 					<div class="bubble-you">
-						Un vote concernant la neutralité du Net aura lieu le 24 février si j'ai bien compris. J'aimerais connaitre la position de Mme/M [NomDeL'élu(e)] à ce sujet.
+						Un vote concernant la neutralité du Net aura lieu le 24 février si j'ai bien compris. J'aimerais connaitre la position de Mme/M.&nbsp;[NomDeL'élu·e] à ce sujet.
 					</div>
 				</p>
 				<div class=clr></div>
@@ -376,36 +376,36 @@
 				<p>
 					<div class="ava-you">Vous</div> 
 					<div class="bubble-you">
-					De <a href="#critics">nombreux observateurs</a> préviennent que si cette régulation passe telle quelle, nous perdrons les effets positifs qu'Internet a sur notre démocratie et notre économie. Nous devons empêcher les fournisseurs d'accès à Internet de créer un Internet de seconde classe pour tous ceux qui n'auront pas les moyens d'accéder à la voie rapide. Mme/M [NomDeL'élu(e)] devrait voter contre la destruction de l'Internet libre et ouvert.
+					De <a href="#critics">nombreux/euses observateurs/trices</a> préviennent que si cette régulation passe telle quelle, nous perdrons les effets positifs qu'Internet a sur notre démocratie et notre économie. Nous devons empêcher les fournisseurs d'accès à Internet de créer un Internet de seconde classe pour tous ceux qui n'auront pas les moyens d'accéder à la voie rapide. Mme/M.&nbsp;[NomDeL'élu·e] devrait voter contre la destruction de l'Internet libre et ouvert.
 					</div>
 				</p>
 				<div class=clr></div>
 				<p>
 					<div class="ava-assistant">Assistant/e</div> 
 					<div class="bubble-assistant">
-					D'accord, j'en parlerai à Mme/M [NomDeL'élu(e)].
+					D'accord, j'en parlerai à Mme/M.&nbsp;[NomDeL'élu·e].
 					</div>
 				</p>
 				<div class=clr></div>
 				<p>
 					<div class="ava-you">Vous</div> 
 					<div class="bubble-you">
-					Merci beaucoup de m'avoir écouté/e. Si vous le souhaitez, je peux vous envoyer des documents de référence. Je rappellerai sous peu pour savoir ce que Mme/M [NomDeL'élu(e)] en a pensé. Je vous souhaite une bonne journée.
+					Merci beaucoup de m'avoir écouté·e. Si vous le souhaitez, je peux vous envoyer des documents de référence. Je rappellerai sous peu pour savoir ce que Mme/M.&nbsp;[NomDeL'élu·e] en a pensé. Je vous souhaite une bonne journée.
 					</div>
 				</p>
 				<div class=clr></div>
-				<p>Et maintenant… Appelez un autre eurodéputé ;)</p>
+				<p>Et maintenant… Appelez un·e autre eurodéputé·e ;)</p>
 				</div>
 
 				<h4>Email</h4>
-				<p>Si vous n'êtes pas à l'aise au téléphone, vous pouvez aussi <b>contacter votre eurodéputé par email</b>. Vous pouvez trouver leurs adresses dans le <a href="#act"widget</a> mail ci-dessus ou sur <a rel="nofollow" class="external text" href="http://memopol.lqdn.fr/">Memopol.</a>.</p>
-				<p>Certains proposent parfois d'envoyer des emails génériques à tous les eurodéputés (y compris à ceux qui ne votent pas sur le sujet en question). Nous estimons que ces emails sont inutiles, voire contre productifs. Les députés et leurs assistants savent aussi bien que vous utiliser des filtres anti-spam, et ces messages finissent rapidement dans leur dossier "spam". Les emails génériques donnent l'impression que vous n'accordez pas suffisamment d'importance au sujet pour prendre le temps d'envoyer un message personnalisé, et ne reflètent même pas le nombre de personnes s'impliquant (une seule personne peut envoyer le même message plusieurs fois). Pire, ces emails augmentent le risque que les élus ne lisent plus les messages personnalisés concernant ce sujet, et finalement le déservent votre action. Si vous souhaitez vraiment ajouter votre nom à un texte déjà écrit, vous feriez mieux de signer une pétition.</p>
-				<p>La meilleure solution est d'envoyer un email reflétant votre propre approche et vos connaissances du sujet (souvenez-vous&nbsp;: personne n'attend de vous que vous soyez un expert, seulement un citoyen concerné) et, si possible, adapté aux positions du groupe de l'élu. </p>
+				<p>Si vous n'êtes pas à l'aise au téléphone, vous pouvez aussi <b>contacter votre eurodéputé·e par email</b>. Vous pouvez trouver leurs adresses dans le <a href="#act"widget</a> mail ci-dessus ou sur <a rel="nofollow" class="external text" href="http://memopol.lqdn.fr/">Memopol.</a>.</p>
+				<p>Certains proposent parfois d'envoyer des emails génériques à tou·te·s les eurodéputé·e·s (y compris à ceux et celles qui ne votent pas sur le sujet en question). Nous estimons que ces emails sont inutiles, voire contre productifs. Les député·e·s et leurs assistant·e·s savent aussi bien que vous utiliser des filtres anti-spam, et ces messages finissent rapidement dans leur dossier "spam". Les emails génériques donnent l'impression que vous n'accordez pas suffisamment d'importance au sujet pour prendre le temps d'envoyer un message personnalisé, et ne reflètent même pas le nombre de personnes s'impliquant (une seule personne peut envoyer le même message plusieurs fois). Pire, ces emails augmentent le risque que les élu·e·s ne lisent plus les messages personnalisés concernant ce sujet, et finalement le déservent votre action. Si vous souhaitez vraiment ajouter votre nom à un texte déjà écrit, vous feriez mieux de signer une pétition.</p>
+				<p>La meilleure solution est d'envoyer un email reflétant votre propre approche et vos connaissances du sujet (souvenez-vous&nbsp;: personne n'attend de vous que vous soyez un·e expert·e, seulement un·e citoyen·ne concerné·e) et, si possible, adapté·e aux positions du groupe de l'élu·e.</p>
 
 				<div class="moaromg">
 					<a href="#act" class="omgbutton">
 						<img src="/img/phoneicon.png" class=vmid> 
-						<span class=vmid>Appelez votre eurodéputé sans attendre&nbsp;!</span>
+						<span class=vmid>Appelez votre eurodéputé·e sans attendre&nbsp;!</span>
 					</a>
 				</div>
 				
@@ -427,7 +427,7 @@
 
 				<h3>Espace presse</h3>
 				<p>Notre équipe sera ravie de répondre à toutes les demandes des médias. Envoyez-nous un email à <b><span class="mailcheat" locip="press" domip="savetheinternet.eu">press /à/ savetheinternet.eu</span></b>.</p>
-					<p>Des experts locaux sont disponibles pour des interviews dans de nombreux pays européens. <br/>Des images sont disponibles <a href="/f/press/press-pics.zip">ici</a> (archive zip).</p>
+					<p>Des expert·e·s locaux/ales sont disponibles pour des interviews dans de nombreux pays européens. <br/>Des images sont disponibles <a href="/f/press/press-pics.zip">ici</a> (archive zip).</p>
 
 				<h3>Aidez-nous à relayer notre message</h3>
 				<center>
@@ -685,7 +685,7 @@
 	
 	<footer class=widesec>
 		<div class=contentwidth>
-			<p style="text-align:center;">Nous sommes des citoyens concernés, appartenant à diverses ONG européennes, et soucieux de défendre les libertés publiques dans le monde numérique.<br> 
+			<p style="text-align:center;">Nous sommes des citoyen·ne·s concerné·e·s, appartenant à diverses ONG européennes, et soucieux/euses de défendre les libertés publiques dans le monde numérique.<br> 
 			Cette campagne est menée par&nbsp;:</p>
 			<ul class=footerlogos>
 			<li>

--- a/fr/index.html
+++ b/fr/index.html
@@ -1,770 +1,734 @@
 <!DOCTYPE html>
-
-<html>
-
-<head>
-	<title>Sauvons Internet - contactez vos eurodéputé·e·s sans attendre&nbsp;!</title>
-	<link rel="stylesheet" type="text/css" href="/css/cyber.css">
-	<meta http-equiv="content-type" content="text/html; charset=utf-8" charset="utf-8">
-	<meta name="description" content="Save the Internet in Europe">
-	<link rel="icon" href="/img/favicon.png" type="image/png">
-  <meta name="author" content="Initiative für Netzfreiheit, European Digital Rights">
-  <meta name="keywords" content="net neutrality, connected conntinent, digital single market, dsm, neelie kroes, Netzneutralität, drosselkom, specialised services, echtesnetz, BEREC, Internetneutralität, Plattformneutralität, Neutralitätsdebatte, neutralité du Net, services spécialisés, marché unique des télécommunications">
-  <meta name="date" content="20013-07-30T03:05:07+02:00">
-	<script type="text/javascript" src="/js/jquery-latest.js"></script>
-  <script type="text/javascript" src="/js/strg_s.js"></script>
-</head>
-<body>
-	<noscript>
-		<!-- Piwik Image Tracker -->
-		<img src="https://piwik.netzfreiheit.org/piwik.php?idsite=11&amp;rec=1&amp;action_name=Save+the+Internet" style="border:0" alt="" />
-		<!-- End Piwik -->
-	</noscript>
-
-<div ids=overall>
-	<nav>
-		<div class="left">
-			<a href="#netneutrality">La neutralité du Net&nbsp;?</a>
-			<a href="#howtocall">Contacter un·e élu·e&nbsp;?</a>
-		</div>
-		<div class="right">
-			<a href="#learnmore">En savoir plus</a>
-			<a href="#contact">Contact / Presse</a>
-		</div>
-		<div class="logo">
-			<a href="#act"><nobr>Agissons&nbsp;!</nobr></a>
-		</div>
-	</nav>
-
-	<section id=langswitch>
-		<ul>
-			<li><a href="/en/">EN</a></li>
-			<li><a href="/fr/"><b>FR</b></a></li>
-			<li><a href="/de/">DE</a></li>
-			<li><a href="/pl/">PL</a></li>
-			<li><a href="/es/">ES</a></li>
-			<li><a href="/it/">IT</a></li>
-			<li><a href="/sk/">SK</a></li>
-			<li><a href="/cz/">CZ</a></li>
-			<li><a href="/sq/">SQ</a></li>
-		</ul>
-	</section>
-			
-	<section class=widesec id=header>
-		<div class=contentwidth>
-			<div id=shareside>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="fr" lang="fr">
+	<head>
+		<title>Sauvons Internet — contactez vos eurodéputé·e·s sans attendre !</title>
+		<meta http-equiv="content-type" content="text/html; charset=utf-8" charset="utf-8" />
+		<meta name="date" content="2013-07-30T03:05:07+02:00" />
+		<meta name="description" content="Save the Internet in Europe" />
+		<meta name="author" content="Initiative für Netzfreiheit, European Digital Rights" />
+		<meta name="keywords" content="net neutrality, connected conntinent, digital single market, dsm, neelie kroes, Netzneutralität, drosselkom, specialised services, echtesnetz, BEREC, Internetneutralität, Plattformneutralität, Neutralitätsdebatte, neutralité du Net, services spécialisés, marché unique des télécommunications" />
+		<link rel="stylesheet" type="text/css" href="/css/cyber.css" />
+		<link rel="icon" href="/img/favicon.png" type="image/png" />
+		<script type="text/javascript" src="/js/jquery-latest.js" />
+		<script type="text/javascript" src="/js/strg_s.js" />
+	</head>
+	<body>
+		<noscript>
+			<!-- Piwik Image Tracker -->
+			<img src="https://piwik.netzfreiheit.org/piwik.php?idsite=11&amp;rec=1&amp;action_name=Save+the+Internet" style="border:0" alt="" />
+			<!-- End Piwik -->
+		</noscript>
+		<div id="overall">
+			<nav>
+				<div class="left">
+					<a href="#netneutrality">La neutralité du Net ?</a>
+					<a href="#howtocall">Contacter un·e élu·e ?</a>
+				</div>
+				<div class="right">
+					<a href="#learnmore">En savoir plus</a>
+					<a href="#contact">Contact / Presse</a>
+				</div>
+				<div class="logo">
+					<a href="#act"><nobr>Agissons !</nobr></a>
+				</div>
+			</nav>
+			<section id="langswitch">
 				<ul>
-					<li><a href="http://www.facebook.com/sharer/sharer.php?s=100&p[url]=http://www.savetheinternet.eu/&p[images][0]=http://www.savetheinternet.eu/img/thumbnail.png&p[title]=Help%20Save%20the%20Internet&p[summary]=Your%20freedom%20online%20is%20threatened%20by%20EU%20proposals.%20The%20fight%20for%20an%20open%20Internet%20is%20happening%20right%20now%20in%20Brussels."><img src="/img/share_fb.png"></a></li>
-					<li><a href="http://twitter.com/home?status=Help%20save%20the%20internet.%20Tell%20your%20politician%20to%20safeguard%20net%20neutrality.%20http://www.savetheinternet.eu/%20%23ConnectedContinent%20#SaveTheInternetEU"><img src="/img/share_tw.png"></a></li>
-					<li><a href="https://plus.google.com/share?url=http://www.savetheinternet.eu/"><img src="/img/share_gp.png"></a></li>
+					<li><a href="/en/">EN</a></li>
+					<li><a href="/fr/"><b>FR</b></a></li>
+					<li><a href="/de/">DE</a></li>
+					<li><a href="/pl/">PL</a></li>
+					<li><a href="/es/">ES</a></li>
+					<li><a href="/it/">IT</a></li>
+					<li><a href="/sk/">SK</a></li>
+					<li><a href="/cz/">CZ</a></li>
+					<li><a href="/sq/">SQ</a></li>
 				</ul>
-			</div>
-			<header id=logosec><img  id=logo src="/img/savetheinternet_logo.png" alt="Act now: Save the Internet!"></header>
-			<section id=omg>
-				<div style="max-width:31em; margin: 0 auto">Votre liberté en ligne est menacée par des propositions de l'Union européenne. La bataille pour un Internet ouvert a lieu en ce moment à Bruxelles.</div>
-				<section class=omgbuttonarea>
-					<a href="#act" class="omgbutton">
-						<img src="/img/phoneicon.png" class=vmid> 
-						<span class=vmid>Contactez vos eurodéputé·e·s sans attendre&nbsp;!</span>
-					</a>
-					<div id="orarrow_wrp"><div id=orarrow>POURQUOI&nbsp;?</div></div>
+			</section>
+			
+			<section class="widesec" id="header">
+				<div class="contentwidth">
+					<div id="shareside">
+						<ul>
+							<li><a href="http://www.facebook.com/sharer/sharer.php?s=100&p[url]=http://www.savetheinternet.eu/&p[images][0]=http://www.savetheinternet.eu/img/thumbnail.png&p[title]=Help%20Save%20the%20Internet&p[summary]=Your%20freedom%20online%20is%20threatened%20by%20EU%20proposals.%20The%20fight%20for%20an%20open%20Internet%20is%20happening%20right%20now%20in%20Brussels."><img src="/img/share_fb.png"></a></li>
+							<li><a href="http://twitter.com/home?status=Help%20save%20the%20internet.%20Tell%20your%20politician%20to%20safeguard%20net%20neutrality.%20http://www.savetheinternet.eu/%20%23ConnectedContinent%20#SaveTheInternetEU"><img src="/img/share_tw.png"></a></li>
+							<li><a href="https://plus.google.com/share?url=http://www.savetheinternet.eu/"><img src="/img/share_gp.png"></a></li>
+						</ul>
+					</div>
+					<header id="logosec"><img id="logo" src="/img/savetheinternet_logo.png" alt="Act now: Save the Internet!"></header>
+					<section id="omg">
+						<div style="max-width:31em; margin: 0 auto">Votre liberté en ligne est menacée par des propositions de l'Union européenne. La bataille pour un Internet ouvert a lieu en ce moment à Bruxelles.</div>
+						<section class="omgbuttonarea">
+							<a href="#act" class="omgbutton">
+								<img src="/img/phoneicon.png" class=vmid> 
+								<span class="vmid">Contactez vos eurodéputé·e·s sans attendre !</span>
+							</a>
+							<div id="orarrow_wrp"><div id=orarrow>POURQUOI ?</div></div>
+						</section>
+					</section>
+				</div>
+			</section>
+			<div class="clr"></div>
+			<section class="widesec" id="why1">
+				<div class=contentwidth>
+					<div class="count">1.</div>
+					<div class="descmain">
+						<div class="headlinewrp">
+							<h2 class="headline">
+								Vous pourriez avoir à payer des frais supplémentaires pour chaque service Internet
+							</h2>
+						</div>
+						<div class="desctext">
+							Un règlement proposé par la Commission européenne pourrait permettre aux fournisseurs d'accès à Internet (FAI) de faire payer des frais supplémentaires pour chaque service en ligne. Ce qu'ils appellent des « services spécialisés » pourrait conduire à un Internet à deux vitesses, où seules les entreprises en ayant les moyens pourraient bénéficier de la voie rapide, laissant tou·te·s les autres sur le carreau.
+						</div>
+						<div class="clr"></div>
+						<div class="whypic" id="whypic1"><img id="whypicimg1" src="/img/specialized_services.png"></div>
+					</div>
+				</div>
+				<div id="floor1"></div>
+			</section>
+			<div class="clr"></div>
+			<section class="widesec" id="why2">
+				<div class="contentwidth">
+					<div class="count">2.</div>
+					<div class="descmain">
+						<img src="/img/provider_control.png" style="float:right; margin: -40px 0 -30px;"> 
+						<div class="headlinewrp"><h2 class="headline" id="whyheadline2">
+								Les fournisseurs d'accès à Internet contrôleraient ce que vous pouvez faire ou non en ligne
+						</h2></div>
+						<div class=desctext style="max-width:31em;">
+							À moins que le règlement ne soit modifié, les fournisseurs d'accès à Internet pourront bloquer du contenu sans aucune contrôle du pouvoir judiciaire. Ces acteurs ne devraient pas devenir la police d'Internet, ni être autorisés à décider des contenus auxquels nous pouvons ou non accéder.
+						</div>
+						<div class="clr"></div>
+						<!--<div class="whypic"><img src="/img/bla.png"></div>-->
+					</div>
+				</div>
+				<div id="floor2"></div>
+			</section>
+			<div class="clr"></div>
+			<section class="widesec" id="why3">
+				<div class="contentwidth">
+					<div class="count">3.</div>
+					<div class="descmain">
+						<div class="whypic" id="whypic3"><img src="/img/internet_monopoly.png"></div>
+						<div class="headlinewrp"><h2 class="headline"  id="whyheadline3">
+								La liberté d'expression serait restreinte et l'innovation entravée
+						</h2></div>
+						<div class="desctext" id="whytext3" style="max-width:27em;">
+							Pour le moment, les grandes entreprises comme Microsoft ou Facebook sont logées à la même enseigne que nos blogs ou podcasts. Mais si la définition des « services spécialisés » n'était pas délimitée, ces sociétés pourraient bénéficier de la voie rapide de l'autoroute de l'information, laissant derrière elles les start-ups et les sites à buts non-lucratifs comme Wikipédia.
+						</div>
+						<div class="clr"></div>
+					</div>
+				</div>
+				<div id="floor3"></div>
+			</section>
+			<div class="clr"></div>
+			<span id="act" class="anchor"></span>
+			<section class="widesec" id="actsection">
+				<div class="contentwidth">
+					<div class="indentarea2">
+						<article id="actteaser">
+							<h3 style="font-size:2em; margin: .2em 0;">Agissons maintenant :</h3>
+							<p>Un règlement proposé par la Commission européenne pourrait permettre aux fournisseurs d'accès à internet (FAI) de faire payer une participation pour chaque service Internet. Ce qu'ils appellent des <b>« services spécialisés »</b> pourrait conduire à un Internet à <b>deux vitesses</b>, où <b>seules les entreprises en ayant les moyens pourraient bénéficier de la voie rapide</b>, laissant tous les autres sur le carreau.</p>
+							<p>À moins que le règlement ne soit modifié, les fournisseurs pourront bloquer du contenu sans aucune contrôle du pouvoir judiciaire. Ils ne devraient pas devenir la police d'Internet, ni pouvoir décider des contenus auxquels nous pouvons ou non accéder. Vous trouverez .<a href="#arguments">d'autres d'arguments ci-dessous</a>.</p>
+							<p><b>En ce moment même, le Parlement européen décide de l'avenir de vos droits et vos libertés ! Le vote de la commission en charge de ce dossier au Parlement européen (la commission Industrie / ITRE) est prévu le 24 février.</b></p>
+						</article>
+						<div class="actiontabs">
+							<a class="actiontab actiontab_phone active" href="#act" onClick="handle_actiontab('phone')"><img src="/img/act_i_phone.png"> Téléphone</a>
+							<a class="actiontab actiontab_fax" href="#act" onClick="handle_actiontab('fax')"><img src="/img/act_i_fax.png"> Fax</a>
+							<a class="actiontab actiontab_mail" href="#act" onClick="handle_actiontab('mail')"><img src="/img/act_i_email.png"> Email</a>
+						</div>
+						<div class="actioncontent">
+							<div id="calliframe">
+								<object
+									 data="http://piphone.lqdn.fr/campaign/widget2/NetNeutrality-ITRE-nov_13/horiz/fr"
+									 width="640" height="180" style="margin:-1px;overflow:hidden;" ></object>	
+							</div>
+							<div id="mailiframe" style="display: none">
+								<object data="http://pimail.tentacleriot.eu/" width="630" height="390" ></object>
+							</div>
+							<div id="faxiframe" style="display: none">
+								<object data="//pimail.tentacleriot.eu/fax/" width="630" height="390" ></object>
+							</div>
+							<div style="padding:10px;">
+								<a href="#act" onclick="nextmep()" id="nextmep">
+									Choisir un autre député au hasard
+								</a>
+								<b>Aide :</b><br>
+								&rarrow; <a href="#learnmore">D'autres arguments</a><br>
+								&rarrow; <a href="#howtocall">Comment contacter un·e eurodéputé·e ?</a>
+							</div>
+						</div>
+						<div class="clr"></div>
+						<div class="shareit">
+							<h3 style="font-size:1.3em">… et faites passer le message !</h3>
+							<div class="hmid">
+								<a href="http://www.facebook.com/sharer/sharer.php?s=100&p[url]=http://www.savetheinternet.eu/&p[images][0]=http://www.savetheinternet.eu/img/thumbnail.png&p[title]=Help%20Save%20the%20Internet&p[summary]=Your%20freedom%20online%20is%20threatened%20by%20EU%20proposals.%20The%20fight%20for%20an%20open%20Internet%20is%20happening%20right%20now%20in%20Brussels." class="sharebt sm-fb"><img src="/img/share_i_fb.png" class="vmid"> <span class="vmid">Facebook</span></a>
+								<a href="http://twitter.com/home?status=Help%20save%20the%20internet.%20Tell%20your%20politician%20to%20safeguard%20net%20neutrality.%20http://www.savetheinternet.eu/%20%23ConnectedContinent%20#SaveTheInternetEU" class="sharebt sm-tw"><img src="/img/share_i_tw.png" class="vmid"> <span class="vmid">Twitter</span></a>
+								<a href="https://plus.google.com/share?url=http://www.savetheinternet.eu/" class="sharebt sm-gp"><img src="/img/share_i_gp.png" class="vmid"> <span class="vmid">Google+</span></a>
+							</div>
+						</div>
+					</div>
+				</div>
+			</section>
+			<span id="netneutrality" class="anchor"></span>
+			<section class="widesec">
+				<div class="contentwidth">
+					<div class="indentarea2">
+						<h3>Qu'est-ce que la neutralité du Net ?</h3>
+						<iframe width="720" height="420" src="//www.youtube-nocookie.com/embed/GJmSrTVKOEw?list=UUFA4cJ6G8qu1S4xU2pVJpLg" frameborder="0" allowfullscreen=""></iframe>
+						<p>La neutralité du réseau est le principe fondamental pour un Internet ouvert. Il assure qu'Internet demeure une plateforme permettant de jouir pleinement des droits de l'homme et de l'innovation. La neutralité du Net garantit que toutes les données circulant sur Internet soient traitées de manière identique, quelle que soit leur origine, leur nature, ou leur destination.</p>
+						<p>La Commission européenne a promis de préserver le principe fondateur d'Internet dans son règlement, mais le texte proposé ne garantit pas la neutralité du Net. À moins que vous n'agissiez pour aider le Parlement européen à amender le texte, Internet ressemblera bientôt à la télévision par câble, où votre opérateur contrôle tout ce à quoi vous pouvez accéder, et peut même vous faire payer des suppléments pour certains services.</p>
+						<p>Nous avons besoin de votre aide pour faire entendre aux parlementaires l'importance de protéger l'Internet libre et ouvert. Dites-leur de protéger la neutralité du réseau !</p>
+						<p>D'autres choses que vous voudriez apprendre au sujet de la neutralité du Net :</p>
+						<iframe width="720" height="420" src="//www.youtube-nocookie.com/embed/dLi7bxZ33Yo" frameborder="0" allowfullscreen=""></iframe>
+						<div class="moaromg">
+							<a href="#act" class="omgbutton">
+								<img src="/img/phoneicon.png" class="vmid">
+								<span class="vmid">Appelez votre eurodéputé·e sans attendre !</span>
+							</a>
+						</div>
+					</div>
+				</div>
+			</section>
+			<span id="learnmore" class="anchor"></span>
+			<section class="widesec">
+				<div class="contentwidth">
+					<div class="indentarea2">
+						<h3>Que se passe-t-il dans l'Union européenne ?</h3>
+						<p>M<sup style="font-variant:small-caps">me</sup> Neelie Kroes, la commissaire en charge des affaires numériques, a promis de préserver la neutralité du réseau. Mais ces dernières années, sa position a radicalement évolué dans une direction contraire. <a href="http://ec.europa.eu/information_society/newsroom/cf/dae/document.cfm?doc_id=2734">Sa proposition de Règlement pour un Marché unique des télécommunications le confirme</a>. Même si nous saluons l'intention d'inscrire la neutralité du Net dans une loi s'appliquant à l'ensemble de l'Union européenne, cette proposition contient de graves failles et ne garantit pas la neutralité du Net promise. Cependant, ce texte pourrait attendre cet objectif. Correctement amendé, il pourrait assurer l'application inconditionnelle de la neutralité du Net dans toute l'Union européenne. La proposition est maintenant entre les mains du Parlement, et sera examinée par plusieurs commissions, et notamment celle de l'industrie, la recherche et l'énergie, en charge de ce dossier. Les modifications proposées par certaines commissions ont malheureusement aggravé les points problématiques de la proposition de la Commission. De plus, l'examen de ce dossier suit à un calendrier très serré, puisque le Parlement souhaite conclure ces négociations avant les élections de mai 2014, et a considérablement réduit le temps de la consultation.</p>
+						<center>
+							<iframe src="https://mediakit.laquadrature.net/embed/1174?size=medium&amp;onlyvideo" style="width:640px; height:360px; border: 0; overflow: hidden" scrolling="no" frameborder="0"></iframe>
+						</center>
+						<h3 id="arguments">Arguments</h3>
+						<h4>Services spécialisés</h4>
+						<p>Les entreprises d'Internet réclament, de manière raisonnable, le droit d'offrir des services spécialisés sur leur réseau – tels que la vidéo haute définition – à des vitesses garanties pour des applications industrielles précises. Tant que ces services sont gérés séparément d'Internet, et n'interfèrent pas avec la qualité d'Internet, ceci ne pose clairement aucun problème.</p>
+						<p>En l'état, la proposition de Règlement ne définit pas clairement ce que sont ces « services spécialisés ». Ainsi, ils peuvent faire l'objet d'une définition large, incluant n'importe quel type de service en ligne. Ceci pourrait conduire à la création d'un Internet à deux vitesses, où certains services prioritaires, et d'autres relégués aux voies lentes, et donc à une limitation de la liberté de communication et des possibilités à l'innovation. (Article 2.15)</p>
+						<p><b>Exemple :</b> De nombreux opérateurs mobiles proposent déjà un accès illimité à Facebook tout en faisant payer les autres services, en fonction de la quantité de données téléchargées. Si la définition d'un « service spécialisé » permet ce type d'offres, elle réduira les possibilités pour les concurrents potentiels d'investir ce marché, freinera l'innovation, et réduira le choix disponible pour les consommateurs à long terme.</p>
+						<p><b>Il est donc indispensable</b> de clarifier la définition de ces termes et de garantir que le « service » en question n'a pas de fonctionalité identique à celle d'un service en ligne, et qu'il est disponible sur un réseau complètement séparé du réseau Internet public. L'Organe des régulateurs européens des communications électroniques (ORECE, ou BEREC en anglais) affirme que de tels services doivent être séparés du service Internet dit de « best effort » et ne doivent être fournis qu'en utilisant le réseau européen du fournisseur d'accès. En plus d'être bien moins claire que cette définition, la proposition de la Commission y ajoute des termes tels que « substantiellement », « général », « largement », dont l'absence de définition ne peut que contribuer au flou législatif.</p>
+						<h4>La « liberté » des utilisateurs finaux</h4>
+						<p>Le texte proposé par la Commission européenne donnerait aux utilisateurs la « liberté » de choisir des services discriminatoires. Cette « liberté » aura, en fin de compte, des conséquences négatives pour les utilisateurs d'Internet et plus largement dans le domaine de l'innovation en ligne (article 23).</p>
+						<p><b>Exemple :</b> Selon une estimation, les consommateurs britanniques paient, à eux seuls, environ 5 milliards de livres de trop, grâce à leur « liberté » de choisir entre plusieurs services aux options opaques.</p>
+						<p><b>Il est donc indispensable</b> de remplacer les termes « sont libres » par « ont le droit » et garantir que le texte n'autorise pas les fournisseurs d'accès à Internet à offrir des services discriminatoires.</p>
+						<h4>« Prévenir ou lutter contre les infractions graves »</h4>
+						<p>Il n'existe pas de définition des « infractions graves ». De même, les termes « mesures appropriées pour empêcher » sont mal définis. Cependant, il est évident dans le contexte que « prévenir ou lutter contre les infractions graves » signifie autoriser les fournisseurs d'accès à Internet à interférer au cas par cas avec les communications en ligne, sans base légale ou décision judiciaire. (Article 23.5).</p>
+						<p><b>Exemple :</b> Au Royaume-Uni, les FAI mettent déjà volontairement en œuvre des mesures provoquant le blocage de divers services en ligne, hors de tout cadre juridique, et alors que ceux-ci sont légaux. En 2012, ces mesures ont conduit au blocage accidentel du site du groupe de défense des libertés numériques français La Quadrature du Net.</p>
+						<p><b>Il est donc indispensable</b> de supprimer cette dangereuse exception facilitant les immixtions arbitraires dans les flux de paquets, puisque cette clause est une violation manifeste de l'article 52 de la charte des droits fondamentaux.</p>
+						<p>Pour en savoir plus, lisez notre avis sur la proposition de Règlement (<a href="https://s3.amazonaws.com/access.3cdn.net/eb2b4943583975dddc_wem6ivd90.pdf">ici</a>) ainsi que les amendements que nous proposons pour améliorer le texte (<a href="https://s3.amazonaws.com/access.3cdn.net/7a87df88dc742379d9_7tm6iiq24.pdf">ici</a>).</p>
+						<h4>Calendrier</h4>
+						<table>
+							<tbody>
+								<thead>
+									<tr>
+										<th></th>
+										<th>ITRE <br> <small>Industrie, recherche et énergie</small></th>
+										<th>IMCO <br> <small>Marché intérieur et protection des consommateurs</small></th>
+										<th>CULT <br> <small>Culture et éducation</small></th>
+										<th>JURI <br> <small>Affaires juridiques</small></th>
+										<th>LIBE <br> <small>Libertés civiles, justice et affaires intérieures</small></th>
+									</tr>
+								</thead>
+								<tr>
+									<td class="thl">Projets d'avis</td>
+									<td><span class="happened"><a href="http://www.edri.org/files/EDRi-comments-draft-ITRE-report.pdf">14/11</a></span></td>
+									<td><span class="happened"><a href="http://www.edri.org/files/EDRi-comments-draft-IMCO-opinion.pdf">11/11</a></span></td>
+									<td><span class="happened"><a href="http://www.edri.org/files/EDRi-comments-draft-CULT-opinion.pdf">20/11</a></span></td>
+									<td><span class="happened">16/12</span></td>
+									<td><span class="happened">09/01</span></td>
+								</tr>
+								<tr>
+									<td class="thl">Date butoire pour les amendements</td>
+									<td><span class="happened">17/12</span></td>
+									<td><span class="happened">03/12</span></td>
+									<td><span class="happened">05/12</span></td>
+									<td><span class="happened">19/12</span></td>
+									<td><span class="happened">16/01</span></td>
+								</tr>
+								<tr>
+									<td class="thl">Examen des propositions d'amendements</td>
+									<td><span class="happened">22-23/01</span></td>
+									<td><span class="happened">09/01</span></td>
+									<td></td>
+									<td></td>
+									<td></td>
+								</tr>
+								<tr>
+									<td class="thl">Vote et rapport définitif</td>
+									<td>24/02</td>
+									<td><span class="happened"><a href="https://www.accessnow.org/blog/2014/01/23/third-european-vote-on-the-telecom-single-market-one-more-step-towards-net-">23/01</a></span></td>
+									<td><span class="happened"><a href="https://www.accessnow.org/blog/2014/01/21/first-two-votes-on-net-neutrality-some-sweet-some-sour-weve-got-a-long-road">21/01</a></span></td>
+									<td><span class="happened"><a href="https://www.accessnow.org/blog/2014/01/21/first-two-votes-on-net-neutrality-some-sweet-some-sour-weve-got-a-long-road">21/01</a></span></td>
+									<td>12/02</td>
+								</tr>
+							</tbody>
+						</table>
+					</div>
+				</div>
+				<span id="critics" class="anchor"></span>
+				<section class="widesec">
+					<div class="contentwidth"> 
+						<div class="indentarea2"> 
+							<h3>Critiques notables</h3>
+							<p>La proposition de Règlement a été critiquée par de nombreuses institutions et citoyens. Avant même qu'une version de travail ne soit annoncée publiquement, <a href="http://edri.org/NN-negativeopinions/">certains membres de la Commission européenne</a> la critiquaient et dénonçaient cette proposition comme une menace pour la neutralité du Net et les droits fondamentaux.</p>
+							<p>Une autre critique de poids a été exprimée par l'<a href="http://berec.europa.eu/eng/document_register/subject_matter/berec/opinions/?doc=2922">Organe des régulateurs européens des communications électroniques</a> (ORECE ou BEREC en anglais). Ce groupe d'expertise indépendant des autorités de régulation nationales a facilité la discussion factuelle au sujet de la neutralité du Net et est <a href="http://berec.europa.eu/eng/document_register/subject_matter/berec/regulatory_best_practices/guidelines/1101-berec-guidelines-for-quality-of-service-in-the-scope-of-net-neutrality">à l'origine de nombreuses définitions très utiles</a> (par exemple pour les services spécialisés). De plus, l'ORECE a établi des données statistiques démontrant que <a href="https://unsernetz.at/links/berec-eu-violations/">la moitié de la population européenne est victime de violation du principe de la neutralité du Net</a> dans le secteur de la téléphonie mobile. Le <a href="http://europa.eu/rapid/press-release_EDPS-13-10_en.htm">Contrôleur européen de la protection des données</a> a également exprimé son inquiétude au sujet des failles juridiques concernant la neutralité du Net et a souligné les dangers que représente la proposition de Règlement pour la protection des données.</p>
+							<p>Enfin, la société civile a examiné très attentivement cette proposition de Règlement européen. Une présentation détaillée des enjeux de ce dossier est disponible sur les sites Internet d'<a href="https://www.accessnow.org/policy/Network-Discrimination-Europe">Access Now</a>, de l'<a href="http://edri.org/european-parliament-to-decide-on-the-future-of-the-open-internet/">European Digital Rights</a>, ainsi que sur celui de <a href="https://www.laquadrature.net/fr/neutralite_du_Net">La Quadrature du Net</a>.</p>
+							<div class="moaromg">
+								<a href="#act" class="omgbutton">
+									<img src="/img/phoneicon.png" class=vmid> 
+									<span class="vmid">Appelez votre eurodéputé sans attendre !</span>
+								</a>
+							</div>
+						</div>
+					</div>
 				</section>
 			</section>
-		</div>
-	</section>
-	<div class=clr></div>
-	<section class=widesec id=why1>
-		<div class=contentwidth>
-			<div class=count>1.</div>
-			<div class=descmain>
-				<div class=headlinewrp><h2 class=headline>
-					Vous pourriez avoir à payer des frais supplémentaires pour chaque service Internet
-				</h2></div>
-				<div class=desctext>
-					Un règlement proposé par la Commission européenne pourrait permettre aux fournisseurs d'accès à Internet (FAI) de faire payer des frais supplémentaires pour chaque service en ligne. Ce qu'ils appellent des «&nbsp;services spécialisés&nbsp;» pourrait conduire à un Internet à deux vitesses, où seules les entreprises en ayant les moyens pourraient bénéficier de la voie rapide, laissant tou·te·s les autres sur le carreau.
-				</div>
-				<div class=clr></div>
-				<div class=whypic id=whypic1><img id=whypicimg1 src="/img/specialized_services.png"></div>
-			</div>
-		</div>
-		<div id=floor1></div>
-	</section>
-	<div class=clr></div>
-	<section class=widesec id=why2>
-		<div class=contentwidth>
-			<div class=count>2.</div>
-			<div class=descmain>
-				<img src="/img/provider_control.png" style="float:right; margin: -40px 0 -30px;"> 
-				<div class=headlinewrp><h2 class=headline id=whyheadline2>
-					Les fournisseurs d'accès à Internet contrôleraient ce que vous pouvez faire ou non en ligne
-				</h2></div>
-				<div class=desctext style="max-width:31em;">
-					À moins que le règlement ne soit modifié, les fournisseurs d'accès à Internet pourront bloquer du contenu sans aucune contrôle du pouvoir judiciaire. Ces acteurs ne devraient pas devenir la police d'Internet, ni être autorisés à décider des contenus auxquels nous pouvons ou non accéder.
-				</div>
-				<div class=clr></div>
-				<!--<div class=whypic><img src="/img/bla.png"></div>-->
-			</div>
-		</div>
-		<div id=floor2></div>
-	</section>
-	<div class=clr></div>
-	<section class=widesec id=why3>
-		<div class=contentwidth>
-			<div class=count>3.</div>
-			<div class=descmain>
-				<div class=whypic id=whypic3><img src="/img/internet_monopoly.png"></div>
-				<div class=headlinewrp><h2 class=headline  id=whyheadline3 >
-					La liberté d'expression serait restreinte et l'innovation entravée
-				</h2></div>
-				<div class=desctext id=whytext3 style="max-width:27em;">
-					Pour le moment, les grandes entreprises comme Microsoft ou Facebook sont logées à la même enseigne que nos blogs ou podcasts. Mais si la définition des «&nbsp;services spécialisés&nbsp;» n'était pas délimitée, ces sociétés pourraient bénéficier de la voie rapide de l'autoroute de l'information, laissant derrière elles les start-ups et les sites à buts non-lucratifs comme Wikipédia.
-				</div>
-				<div class=clr></div>
-			</div>
-		</div>
-		<div id=floor3></div>
-	</section>
-	<div class=clr></div>
-	<span id="act" class="anchor"></span>
-	<section class=widesec id="actsection">
-		<div class=contentwidth>
-			<div class=indentarea2>
 			
-				<article id=actteaser>
-					<h3 style="font-size:2em; margin: .2em 0;">Agissons maintenant&nbsp;:</h3>
-					<p>Un règlement proposé par la Commission européenne pourrait permettre aux fournisseurs d'accès à internet (FAI) de faire payer une participation pour chaque service Internet. Ce qu'ils appellent des <b>«&nbsp;services spécialisés&nbsp;»</b> pourrait conduire à un Internet à <b>deux vitesses</b>, où <b>seules les entreprises en ayant les moyens pourraient bénéficier de la voie rapide</b>, laissant tous les autres sur le carreau.</p>
-
-					<p>À moins que le règlement ne soit modifié, les fournisseurs pourront bloquer du contenu sans aucune contrôle du pouvoir judiciaire. Ils ne devraient pas devenir la police d'Internet, ni pouvoir décider des contenus auxquels nous pouvons ou non accéder. Vous trouverez .<a href="#arguments">d'autres d'arguments ci-dessous</a>.</p>
-
-					<p><b>En ce moment même, le Parlement européen décide de l'avenir de vos droits et vos libertés&nbsp;! Le vote de la commission en charge de ce dossier au Parlement européen (la commission Industrie / ITRE) est prévu le 24 février.</b></p>
-				</article>
-				<div class=actiontabs>
-					<a class="actiontab actiontab_phone active" href="#act" onClick="handle_actiontab('phone')"><img src="/img/act_i_phone.png"> Téléphone</a>
-					<a class="actiontab actiontab_fax" href="#act" onClick="handle_actiontab('fax')"><img src="/img/act_i_fax.png"> Fax</a>
-					<a class="actiontab actiontab_mail" href="#act" onClick="handle_actiontab('mail')"><img src="/img/act_i_email.png"> <nobr>Email</nobr></a>
-				</div>
-				<div class=actioncontent>
-					<div id=calliframe>
-						<object
-            data="http://piphone.lqdn.fr/campaign/widget2/NetNeutrality-ITRE-nov_13/horiz/fr"
-            width="640" height="180" style="margin:-1px;overflow:hidden;" ></object>	
-					</div>
-						
-					<div id=mailiframe style="display: none">
-						<object data="http://pimail.tentacleriot.eu/" width="630" height="390" ></object>
-					</div>
-
-					<div id=faxiframe style="display: none">
-						<object data="//pimail.tentacleriot.eu/fax/" width="630" height="390" ></object>
-					</div>
-					
-					<div style="padding:10px;">
-            <a href="#act" onclick="nextmep()" id="nextmep">
-            Choisir un autre député au hasard
-            </a>
-						<b>Aide&nbsp;:</b><br>
-						&raquo; <a href="#learnmore">D'autres arguments</a><br>
-						&raquo; <a href="#howtocall">Comment contacter un·e eurodéputé·e&nbsp;?</a>
-					</div>
-
-				</div>
-				<div class=clr></div>
-				<div class=shareit>
-				
-				<h3 style="font-size:1.3em">… et faites passer le message&nbsp;!</h3>
-				<div class=hmid>
-					<a href="http://www.facebook.com/sharer/sharer.php?s=100&p[url]=http://www.savetheinternet.eu/&p[images][0]=http://www.savetheinternet.eu/img/thumbnail.png&p[title]=Help%20Save%20the%20Internet&p[summary]=Your%20freedom%20online%20is%20threatened%20by%20EU%20proposals.%20The%20fight%20for%20an%20open%20Internet%20is%20happening%20right%20now%20in%20Brussels." class="sharebt sm-fb"><img src="/img/share_i_fb.png" class=vmid> <span class=vmid>Facebook</span></a>
-					<a href="http://twitter.com/home?status=Help%20save%20the%20internet.%20Tell%20your%20politician%20to%20safeguard%20net%20neutrality.%20http://www.savetheinternet.eu/%20%23ConnectedContinent%20#SaveTheInternetEU" class="sharebt sm-tw"><img src="/img/share_i_tw.png" class=vmid> <span class=vmid>Twitter</span></a>
-					<a href="https://plus.google.com/share?url=http://www.savetheinternet.eu/" class="sharebt sm-gp"><img src="/img/share_i_gp.png" class=vmid> <span class=vmid>Google+</span></a>
-				</div>
-			</div>
-				
-		</div>
-	</section>
-
-	<span id="netneutrality" class="anchor"></span>
-	<section class=widesec>
-		<div class=contentwidth>
-			<div class=indentarea2>
-				<h3>Qu'est-ce que la neutralité du Net&nbsp;?</h3>
-				<iframe width="720" height="420" src="//www.youtube-nocookie.com/embed/GJmSrTVKOEw?list=UUFA4cJ6G8qu1S4xU2pVJpLg" frameborder="0" allowfullscreen></iframe>
-				<p>La neutralité du réseau est le principe fondamental pour un Internet ouvert. Il assure qu'Internet demeure une plateforme permettant de jouir pleinement des droits de l'homme et de l'innovation. La neutralité du Net garantit que toutes les données circulant sur Internet soient traitées de manière identique, quelle que soit leur origine, leur nature, ou leur destination.</p>
-
-				<p>La Commission européenne a promis de préserver le principe fondateur d'Internet dans son règlement, mais le texte proposé ne garantit pas la neutralité du Net. À moins que vous n'agissiez pour aider le Parlement européen à amender le texte, Internet ressemblera bientôt à la télévision par câble, où votre opérateur contrôle tout ce à quoi vous pouvez accéder, et peut même vous faire payer des suppléments pour certains services.</p>
-
-				<p>Nous avons besoin de votre aide pour faire entendre aux parlementaires l'importance de protéger l'Internet libre et ouvert. Dites-leur de protéger la neutralité du réseau&nbsp;!</p>
-				<p>D'autres choses que vous voudriez apprendre au sujet de la neutralité du Net&nbsp;:</p>
-				<iframe width="720" height="420" src="//www.youtube-nocookie.com/embed/dLi7bxZ33Yo" frameborder="0" allowfullscreen></iframe>
-				<div class="moaromg">
-					<a href="#act" class="omgbutton">
-						<img src="/img/phoneicon.png" class=vmid> 
-						<span class=vmid>Appelez votre eurodéputé·e sans attendre&nbsp;! </span>
-					</a>
-				</div>
-			</div>
-		</div>
-	</section>
-
-	<span id="learnmore" class="anchor"></span>
-	<section class=widesec>
-		<div class=contentwidth>
-			<div class=indentarea2>
-
-				<h3>Que se passe-t-il dans l'Union européenne&nbsp;?</h3>
-
-				<p>Mme Neelie Kroes, la commissaire en charge des affaires numériques, a promis de préserver la neutralité du réseau. Mais ces dernières années, sa position a radicalement évolué dans une direction contraire. <a href="http://ec.europa.eu/information_society/newsroom/cf/dae/document.cfm?doc_id=2734">Sa proposition de Règlement pour un Marché unique des télécommunications le confirme</a>. Même si nous saluons l'intention d'inscrire la neutralité du Net dans une loi s'appliquant à l'ensemble de l'Union européenne, cette proposition contient de graves failles et ne garantit pas la neutralité du Net promise. Cependant, ce texte pourrait attendre cet objectif. Correctement amendé, il pourrait assurer l'application inconditionnelle de la neutralité du Net dans toute l'Union européenne. La proposition est maintenant entre les mains du Parlement, et sera examinée par plusieurs commissions, et notamment celle de l'industrie, la recherche et l'énergie, en charge de ce dossier. Les modifications proposées par certaines commissions ont malheureusement aggravé les points problématiques de la proposition de la Commission. De plus, l'examen de ce dossier suit à un calendrier très serré, puisque le Parlement souhaite conclure ces négociations avant les élections de mai 2014, et a considérablement réduit le temps de la consultation.</p>
-
-				<center>
-				<iframe src="https://mediakit.laquadrature.net/embed/1174?size=medium&amp;onlyvideo" style="width:640px; height:360px; border: 0; overflow: hidden" scrolling="no" frameborder="0"></iframe>
-				</center>
-					
-				<h3 id="arguments">Arguments</h3>
-				<h4>Services spécialisés</h4>
-				<p>Les entreprises d'Internet réclament, de manière raisonnable, le droit d'offrir des services spécialisés sur leur réseau – tels que la vidéo haute définition – à des vitesses garanties pour des applications industrielles précises. Tant que ces services sont gérés séparément d'Internet, et n'interfèrent pas avec la qualité d'Internet, ceci ne pose clairement aucun problème.</p>
-				<p>En l'état, la proposition de Règlement ne définit pas clairement ce que sont ces «&nbsp;services spécialisés&nbsp;». Ainsi, ils peuvent faire l'objet d'une définition large, incluant n'importe quel type de service en ligne. Ceci pourrait conduire à la création d'un Internet à deux vitesses, où certains services prioritaires, et d'autres relégués aux voies lentes, et donc à une limitation de la liberté de communication et des possibilités à l'innovation. (Article 2.15)</p>
-				<p><b>Exemple&nbsp;:</b> De nombreux opérateurs mobiles proposent déjà un accès illimité à Facebook tout en faisant payer les autres services, en fonction de la quantité de données téléchargées. Si la définition d'un «&nbsp;service spécialisé&nbsp;» permet ce type d'offres, elle réduira les possibilités pour les concurrents potentiels d'investir ce marché, freinera l'innovation, et réduira le choix disponible pour les consommateurs à long terme.</p>
-				<p><b>Il est donc indispensable</b> de clarifier la définition de ces termes et de garantir que le «&nbsp;service&nbsp;» en question n'a pas de fonctionalité identique à celle d'un service en ligne, et qu'il est disponible sur un réseau complètement séparé du réseau Internet public. L'Organe des régulateurs européens des communications électroniques (ORECE, ou BEREC en anglais) affirme que de tels services doivent être séparés du service Internet dit de «&nbsp;best effort&nbsp;» et ne doivent être fournis qu'en utilisant le réseau européen du fournisseur d'accès. En plus d'être bien moins claire que cette définition, la proposition de la Commission y ajoute des termes tels que «&nbsp;substantiellement&nbsp;», «&nbsp;général&nbsp;», «&nbsp;largement&nbsp;», dont l'absence de définition ne peut que contribuer au flou législatif.</p>
-				<h4>La «&nbsp;liberté&nbsp;» des utilisateurs finaux</h4>
-				<p>Le texte proposé par la Commission européenne donnerait aux utilisateurs la «&nbsp;liberté&nbsp;» de choisir des services discriminatoires. Cette «&nbsp;liberté&nbsp;» aura, en fin de compte, des conséquences négatives pour les utilisateurs d'Internet et plus largement dans le domaine de l'innovation en ligne (article 23).</p>
-				<p><b>Exemple&nbsp;:</b> Selon une estimation, les consommateurs britanniques paient, à eux seuls, environ 5 milliards de livres de trop, grâce à leur «&nbsp;liberté&nbsp;» de choisir entre plusieurs services aux options opaques.</p>
-				<p><b>Il est donc indispensable</b> de remplacer les termes «&nbsp;sont libres&nbsp;» par «&nbsp;ont le droit&nbsp;» et garantir que le texte n'autorise pas les fournisseurs d'accès à Internet à offrir des services discriminatoires.</p>
-
-				<h4>«&nbsp;Prévenir ou lutter contre les infractions graves&nbsp;»</h4>
-				<p>Il n'existe pas de définition des «&nbsp;infractions graves&nbsp;». De même, les termes «&nbsp;mesures appropriées pour empêcher&nbsp;» sont mal définis. Cependant, il est évident dans le contexte que «&nbsp;prévenir ou lutter contre les infractions graves&nbsp;» signifie autoriser les fournisseurs d'accès à Internet à interférer au cas par cas avec les communications en ligne, sans base légale ou décision judiciaire. (Article 23.5).</p>
-				<p><b>Exemple&nbsp;:</b> Au Royaume-Uni, les FAI mettent déjà volontairement en œuvre des mesures provoquant le blocage de divers services en ligne, hors de tout cadre juridique, et alors que ceux-ci sont légaux. En 2012, ces mesures ont conduit au blocage accidentel du site du groupe de défense des libertés numériques français La Quadrature du Net.</p>
-				<p><b>Il est donc indispensable</b> de supprimer cette dangereuse exception facilitant les immixtions arbitraires dans les flux de paquets, puisque cette clause est une violation manifeste de l'article 52 de la charte des droits fondamentaux.</p>
-
-				<p>Pour en savoir plus, lisez notre avis sur la proposition de Règlement (<a href="https://s3.amazonaws.com/access.3cdn.net/eb2b4943583975dddc_wem6ivd90.pdf">ici</a>) ainsi que les amendements que nous proposons pour améliorer le texte (<a href="https://s3.amazonaws.com/access.3cdn.net/7a87df88dc742379d9_7tm6iiq24.pdf">ici</a>).</p>
-				
-				<h4>Calendrier</h4>
-				<table>
-					<tbody>
-					<tr>
-						<th></th>
-						<th>ITRE <br> <small>Industrie, recherche et énergie</small></th>
-						<th>IMCO <br> <small>Marché intérieur et protection des consommateurs</small></th>
-						<th>CULT <br> <small>Culture et éducation</small></th>
-						<th>JURI <br> <small>Affaires juridiques</small></th>
-						<th>LIBE <br> <small>Libertés civiles, justice et affaires intérieures</small></th>
-					</tr>
-					<tr>
-						<td class=thl>Projets d'avis</td>
-						<td><span class="happened"><a href="http://www.edri.org/files/EDRi-comments-draft-ITRE-report.pdf">14/11</a></span></td>
-						<td><span class="happened"><a href="http://www.edri.org/files/EDRi-comments-draft-IMCO-opinion.pdf">11/11</a></span></td>
-						<td><span class="happened"><a href="http://www.edri.org/files/EDRi-comments-draft-CULT-opinion.pdf">20/11</a></span></td>
-						<td><span class="happened">16/12</span></td>
-						<td><span class="happened">09/01</span></td>
-					</tr>
-					<tr>
-						<td class=thl>Date butoire pour les amendements</td>
-						<td><span class="happened">17/12</span></td>
-						<td><span class="happened">03/12</span></td>
-						<td><span class="happened">05/12</span></td>
-						<td><span class="happened">19/12</span></td>
-						<td><span class="happened">16/01</span></td>
-					</tr>
-					<tr>
-						<td class=thl>Examen des propositions d'amendements</td>
-						<td><span class="happened">22-23/01</span></td>
-						<td><span class="happened">09/01</span></td>
-						<td></td>
-						<td></td>
-						<td></td>
-					</tr>
-					<tr>
-						<td class=thl>Vote et rapport définitif</td>
-						<td>24/02</td>
-						<td><span class="happened"><a href="https://www.accessnow.org/blog/2014/01/23/third-european-vote-on-the-telecom-single-market-one-more-step-towards-net-">23/01</a></span></td>
-						<td><span class="happened"><a href="https://www.accessnow.org/blog/2014/01/21/first-two-votes-on-net-neutrality-some-sweet-some-sour-weve-got-a-long-road">21/01</a></span></td>
-						<td><span class="happened"><a href="https://www.accessnow.org/blog/2014/01/21/first-two-votes-on-net-neutrality-some-sweet-some-sour-weve-got-a-long-road">21/01</a></span></td>
-						<td>12/02</td>
-					</tr>
-					</tbody>
-				</table>
-			</div>
-		</div>
-		<span id="critics" class="anchor"></span>
-		<section class=widesec>
-			<div class=contentwidth> 
-				<div class=indentarea2> 
-					
-				<h3>Critiques notables</h3>
-				<p>La proposition de Règlement a été critiquée par de nombreuses institutions et citoyens. Avant même qu'une version de travail ne soit annoncée publiquement, <a href="http://edri.org/NN-negativeopinions/">certains membres de la Commission européenne</a> la critiquaient et dénonçaient cette proposition comme une menace pour la neutralité du Net et les droits fondamentaux.</p>
-
-				<p>Une autre critique de poids a été exprimée par l'<a href="http://berec.europa.eu/eng/document_register/subject_matter/berec/opinions/?doc=2922">Organe des régulateurs européens des communications électroniques</a> (ORECE ou BEREC en anglais). Ce groupe d'expertise indépendant des autorités de régulation nationales a facilité la discussion factuelle au sujet de la neutralité du Net et est <a href="http://berec.europa.eu/eng/document_register/subject_matter/berec/regulatory_best_practices/guidelines/1101-berec-guidelines-for-quality-of-service-in-the-scope-of-net-neutrality">à l'origine de nombreuses définitions très utiles</a> (par exemple pour les services spécialisés). De plus, l'ORECE a établi des données statistiques démontrant que <a href="https://unsernetz.at/links/berec-eu-violations/">la moitié de la population européenne est victime de violation du principe de la neutralité du Net</a> dans le secteur de la téléphonie mobile. Le <a href="http://europa.eu/rapid/press-release_EDPS-13-10_en.htm">Contrôleur européen de la protection des données</a> a également exprimé son inquiétude au sujet des failles juridiques concernant la neutralité du Net et a souligné les dangers que représente la proposition de Règlement pour la protection des données.</p>
-				<p>Enfin, la société civile a examiné très attentivement cette proposition de Règlement européen. Une présentation détaillée des enjeux de ce dossier est disponible sur les sites Internet d'<a href="https://www.accessnow.org/policy/Network-Discrimination-Europe">Access Now</a>, de l'<a href="http://edri.org/european-parliament-to-decide-on-the-future-of-the-open-internet/">European Digital Rights</a>, ainsi que sur celui de <a href="https://www.laquadrature.net/fr/neutralite_du_Net">La Quadrature du Net</a>.</p>
-
-					<div class="moaromg">
-						<a href="#act" class="omgbutton">
-							<img src="/img/phoneicon.png" class=vmid> 
-							<span class=vmid>Appelez votre eurodéputé sans attendre&nbsp;!</span>
-						</a>
-					</div>
-				</div>
-
-			</div>
-		</section>
-	</section>
-
-	<span id="howtocall" class="anchor"></span>
-	<section class=widesec>
-		<div class=contentwidth>
-			<div class=indentarea2>
-
-				<h3>Comment contacter votre eurodéputé·e&nbsp;?</h3>
-				<p><b>Nous avons vaincu ACTA, et nous avons besoin de votre aide pour gagner cette nouvelle bataille. Agissez maintenant et appelez vos député·e·s à protéger vos droits et vos libertés. La meilleure façon d'agir est de contacter directement un membre du Parlement européen. Mais vous pouvez aussi envoyer un fax, une lettre ou un email. Vous trouverez ici toutes les informations nécessaires – et les appels sont gratuits.</b></p>
-
-				<h4>Conseils généraux</h4>
-
-				<ul>
-					<li>Avant tout, informez-vous en <a href="#learnmore">lisant nos documents clés.</a></li>
-					<li>Soyez poli·e et restez vous-même. Quoi qu'il arrive, n'oubliez pas les règles élémentaires de politesse et de bon sens. Que vous soyez ou non d'accord avec votre interlocuteur/trice, et quelles que soient les opinions des autres membres de son groupe politique, ne donnez pas une mauvaise image des personnes qui défendent la même cause que vous.</li>
-					<li>La plupart du temps, vous aurez au bout du fil un·e assistant·e parlementaire, et non directement un·e député·e. Ce n'est pas un problème. Engagez la conversation&nbsp;: les assistant·e·s jouent un rôle important dans la construction des positions des députés.</li>
-					<li>Si votre interlocuteur/trice vous pose une question à laquelle vous ne pouvez pas répondre, ne paniquez pas. Personne n'attend de vous que vous soyez un·e expert·e&nbsp;: vous êtes simplement un·e citoyen·ne inquiet/ète. Dans ce cas, dites à votre interlocuteur/trice que vous allez vous renseigner et le/la recontacterez avec la réponse. N'hésitez pas à nous demander de vous aider.</li>
-					<li>Si vous ne vous sentez toujours pas à l'aise avec les arguments, n'abandonnez pas&nbsp;! Demandez quelle est la position de l’eurodéputé·e et quels sont ses arguments.</li>
-					<li>Lors de vos appels, n'hésitez pas à proposer de rappeler pour offrir plus d'informations, de proposer de rencontrer le/la député·e, d'envoyer des documents, des références… Parfois, les assistant·e·s vous demanderont d'envoyer un email. N'hésitez pas à rappeler un peu plus tard pour vous assurer qu'ils/elles l'ont lu, et leur demander leur avis.</li>
-				</ul>
-
-				<h4>Appel téléphonique</h4>
-				<p>La meilleure manière de faire passer votre message à un·e élu·e et de <b>développer vos arguments de vive voix</b>. De cette manière, vous pourrez adapter votre discours à ses réponses, et exprimer à quel point vous êtes concerné·e par le sujet en question. Les élu·e·s ne reçoivent pas beaucoup d'appels de citoyen·ne·s, et y sont donc particulièrement sensibles.</p>
-
-				<b>Généralement, les conversations se déroulent de cette manière&nbsp;:</b>
-				
-				<div class=chat>
+			<span id="howtocall" class="anchor"></span>
+			<section class="widesec">
+				<div class="contentwidth">
+					<div class="indentarea2">
+						<h3>Comment contacter votre eurodéputé·e ?</h3>
+						<p><strong>Nous avons vaincu ACTA, et nous avons besoin de votre aide pour gagner cette nouvelle bataille. Agissez maintenant et appelez vos député·e·s à protéger vos droits et vos libertés. La meilleure façon d'agir est de contacter directement un membre du Parlement européen. Mais vous pouvez aussi envoyer un fax, une lettre ou un email. Vous trouverez ici toutes les informations nécessaires – et les appels sont gratuits.</strong></p>
+						<h4>Conseils généraux</h4>
+						<ul>
+							<li>Avant tout, informez-vous en <a href="#learnmore">lisant nos documents clés.</a></li>
+							<li>Soyez poli·e et restez vous-même. Quoi qu'il arrive, n'oubliez pas les règles élémentaires de politesse et de bon sens. Que vous soyez ou non d'accord avec votre interlocuteur/trice, et quelles que soient les opinions des autres membres de son groupe politique, ne donnez pas une mauvaise image des personnes qui défendent la même cause que vous.</li>
+							<li>La plupart du temps, vous aurez au bout du fil un·e assistant·e parlementaire, et non directement un·e député·e. Ce n'est pas un problème. Engagez la conversation : les assistant·e·s jouent un rôle important dans la construction des positions des députés.</li>
+							<li>Si votre interlocuteur/trice vous pose une question à laquelle vous ne pouvez pas répondre, ne paniquez pas. Personne n'attend de vous que vous soyez un·e expert·e : vous êtes simplement un·e citoyen·ne inquiet/ète. Dans ce cas, dites à votre interlocuteur/trice que vous allez vous renseigner et le/la recontacterez avec la réponse. N'hésitez pas à nous demander de vous aider.</li>
+							<li>Si vous ne vous sentez toujours pas à l'aise avec les arguments, n'abandonnez pas ! Demandez quelle est la position de l’eurodéputé·e et quels sont ses arguments.</li>
+							<li>Lors de vos appels, n'hésitez pas à proposer de rappeler pour offrir plus d'informations, de proposer de rencontrer le/la député·e, d'envoyer des documents, des références… Parfois, les assistant·e·s vous demanderont d'envoyer un email. N'hésitez pas à rappeler un peu plus tard pour vous assurer qu'ils/elles l'ont lu, et leur demander leur avis.</li>
+						</ul>
+						<h4>Appel téléphonique</h4>
+						<p>La meilleure manière de faire passer votre message à un·e élu·e et de <strong>développer vos arguments de vive voix</strong>. De cette manière, vous pourrez adapter votre discours à ses réponses, et exprimer à quel point vous êtes concerné·e par le sujet en question. Les élu·e·s ne reçoivent pas beaucoup d'appels de citoyen·ne·s, et y sont donc particulièrement sensibles.</p>
+				<b>Généralement, les conversations se déroulent de cette manière :</b>
+				<div class="chat">
+					<p>
+						<div class="ava-you">Vous</div> 
+						<div class="bubble-you">
+							Bonjour, je m'appelle [VotreNom], je suis un·e citoyen·ne européen·ne de [VotrePays], et je souhaiterais parler à Mme/M. [NomDeL'élu·e], s'il vous plaît.
+						</div>
+					</p>
+					<div class="clr"></div>
+					<p>
+						<div class="ava-assistant">Assistant·e</div> 
+						<div class="bubble-assistant">
+							Mme/M. [NomDeL'élu·e] n'est pas disponible, je suis son assistant·e. En quoi puis-je vous aider ?
+						</div>
+					</p>
+					<div class="clr"></div>
+					<p>
+						<div class="ava-you">Vous</div> 
+						<div class="bubble-you">
+							Un vote concernant la neutralité du Net aura lieu le 24 février si j'ai bien compris. J'aimerais connaitre la position de Mme/M. [NomDeL'élu·e] à ce sujet.
+						</div>
+					</p>
+					<div class="clr"></div>
+					<p>
+						<div class="ava-assistant">Assistant·e</div> 
+						<div class="bubble-assistant">
+							Je vois. Nous avons déjà reçu des appels à ce sujet. Je n'ai pas le temps.
+						</div>
+					</p>
+					<div class="clr"></div>
+					<p>
+						<div class="ava-you">Vous</div> 
+						<div class="bubble-you">
+							Mais c'est très important ! Les services spécialisés, tels qu'ils sont définis actuellement, mettent en danger l'Internet neutre et libre, et entravent l'innovation. Les services spécialisés doivent être séparés de l'Internet, comme l'organe des régulateurs européens l'a déjà suggéré.
+						</div>
+					</p>
+					<div class="clr"></div>
 				<p>
-					<div class="ava-you">Vous</div> 
-					<div class="bubble-you">
-						Bonjour, je m'appelle [VotreNom], je suis un·e citoyen·ne européen·ne de [VotrePays], et je souhaiterais parler à Mme/M.&nbsp;[NomDeL'élu·e], s'il vous plaît.
-					</div>
-				</p>
-				<div class=clr></div>
-				<p>
-					<div class="ava-assistant">Assistant/e</div> 
+					<div class="ava-assistant">Assistant·e</div> 
 					<div class="bubble-assistant">
-						Mme/M.&nbsp;[NomDeL'élu·e] n'est pas disponible, je suis son assistant·e. En quoi puis-je vous aider&nbsp;?
+						Ne vous inquiétez pas. Le texte est moins grave que vous ne le croyez, tout va bien se passer.
 					</div>
 				</p>
-				<div class=clr></div>
-				<p>
-					<div class="ava-you">Vous</div> 
-					<div class="bubble-you">
-						Un vote concernant la neutralité du Net aura lieu le 24 février si j'ai bien compris. J'aimerais connaitre la position de Mme/M.&nbsp;[NomDeL'élu·e] à ce sujet.
-					</div>
-				</p>
-				<div class=clr></div>
-				<p>
-					<div class="ava-assistant">Assistant/e</div> 
-					<div class="bubble-assistant">
-					Je vois. Nous avons déjà reçu des appels à ce sujet. Je n'ai pas le temps.
-					</div>
-				</p>
-				<div class=clr></div>
-				<p>
-					<div class="ava-you">Vous</div> 
-					<div class="bubble-you">
-					Mais c'est très important&nbsp;! Les services spécialisés, tels qu'ils sont définis actuellement, mettent en danger l'Internet neutre et libre, et entravent l'innovation. Les services spécialisés doivent être séparés de l'Internet, comme l'organe des régulateurs européens l'a déjà suggéré.
-					</div>
-				</p>
-				<div class=clr></div>
-				<p>
-					<div class="ava-assistant">Assistant/e</div> 
-					<div class="bubble-assistant">
-					Ne vous inquiétez pas. Le texte est moins grave que vous ne le croyez, tout va bien se passer.
-					</div>
-				</p>
-				<div class=clr></div>
-				<p>
-					<div class="ava-you">Vous</div> 
-					<div class="bubble-you">
-					De <a href="#critics">nombreux/euses observateurs/trices</a> préviennent que si cette régulation passe telle quelle, nous perdrons les effets positifs qu'Internet a sur notre démocratie et notre économie. Nous devons empêcher les fournisseurs d'accès à Internet de créer un Internet de seconde classe pour tous ceux qui n'auront pas les moyens d'accéder à la voie rapide. Mme/M.&nbsp;[NomDeL'élu·e] devrait voter contre la destruction de l'Internet libre et ouvert.
-					</div>
-				</p>
-				<div class=clr></div>
-				<p>
-					<div class="ava-assistant">Assistant/e</div> 
-					<div class="bubble-assistant">
-					D'accord, j'en parlerai à Mme/M.&nbsp;[NomDeL'élu·e].
-					</div>
-				</p>
-				<div class=clr></div>
-				<p>
-					<div class="ava-you">Vous</div> 
-					<div class="bubble-you">
-					Merci beaucoup de m'avoir écouté·e. Si vous le souhaitez, je peux vous envoyer des documents de référence. Je rappellerai sous peu pour savoir ce que Mme/M.&nbsp;[NomDeL'élu·e] en a pensé. Je vous souhaite une bonne journée.
-					</div>
-				</p>
-				<div class=clr></div>
-				<p>Et maintenant… Appelez un·e autre eurodéputé·e ;)</p>
+				<div class="clr"></div>
+					<p>
+						<div class="ava-you">Vous</div> 
+						<div class="bubble-you">
+							De <a href="#critics">nombreux/euses observateurs/trices</a> préviennent que si cette régulation passe telle quelle, nous perdrons les effets positifs qu'Internet a sur notre démocratie et notre économie. Nous devons empêcher les fournisseurs d'accès à Internet de créer un Internet de seconde classe pour tous ceux qui n'auront pas les moyens d'accéder à la voie rapide. Mme/M. [NomDeL'élu·e] devrait voter contre la destruction de l'Internet libre et ouvert.
+						</div>
+					</p>
+					<div class="clr"></div>
+					<p>
+						<div class="ava-assistant">Assistant·e</div> 
+						<div class="bubble-assistant">
+							D'accord, j'en parlerai à Mme/M. [NomDeL'élu·e].
+						</div>
+					</p>
+					<div class="clr"></div>
+					<p>
+						<div class="ava-you">Vous</div> 
+						<div class="bubble-you">
+							Merci beaucoup de m'avoir écouté·e. Si vous le souhaitez, je peux vous envoyer des documents de référence. Je rappellerai sous peu pour savoir ce que Mme/M. [NomDeL'élu·e] en a pensé. Je vous souhaite une bonne journée.
+						</div>
+					</p>
+					<div class="clr"></div>
+					<p>Et maintenant… Appelez un·e autre eurodéputé·e ;)</p>
 				</div>
-
+				
 				<h4>Email</h4>
-				<p>Si vous n'êtes pas à l'aise au téléphone, vous pouvez aussi <b>contacter votre eurodéputé·e par email</b>. Vous pouvez trouver leurs adresses dans le <a href="#act"widget</a> mail ci-dessus ou sur <a rel="nofollow" class="external text" href="http://memopol.lqdn.fr/">Memopol.</a>.</p>
-				<p>Certains proposent parfois d'envoyer des emails génériques à tou·te·s les eurodéputé·e·s (y compris à ceux et celles qui ne votent pas sur le sujet en question). Nous estimons que ces emails sont inutiles, voire contre productifs. Les député·e·s et leurs assistant·e·s savent aussi bien que vous utiliser des filtres anti-spam, et ces messages finissent rapidement dans leur dossier "spam". Les emails génériques donnent l'impression que vous n'accordez pas suffisamment d'importance au sujet pour prendre le temps d'envoyer un message personnalisé, et ne reflètent même pas le nombre de personnes s'impliquant (une seule personne peut envoyer le même message plusieurs fois). Pire, ces emails augmentent le risque que les élu·e·s ne lisent plus les messages personnalisés concernant ce sujet, et finalement le déservent votre action. Si vous souhaitez vraiment ajouter votre nom à un texte déjà écrit, vous feriez mieux de signer une pétition.</p>
-				<p>La meilleure solution est d'envoyer un email reflétant votre propre approche et vos connaissances du sujet (souvenez-vous&nbsp;: personne n'attend de vous que vous soyez un·e expert·e, seulement un·e citoyen·ne concerné·e) et, si possible, adapté·e aux positions du groupe de l'élu·e.</p>
-
-				<div class="moaromg">
-					<a href="#act" class="omgbutton">
-						<img src="/img/phoneicon.png" class=vmid> 
-						<span class=vmid>Appelez votre eurodéputé·e sans attendre&nbsp;!</span>
-					</a>
-				</div>
-				
-				</div>
-		</div>
-	</section>
-
-	<span id="contact" class="anchor"></span>
-	<section class=widesec>
-		<div class=contentwidth> 
-			<div class=indentarea2> 
-				
-				<h3>Contact</h3>
-				<p>Vous pouvez nous contacter à <b><span class="mailcheat" locip="info" domip="savetheinternet.eu">info /à/ savetheinternet.eu</span></b></p>
-
-				<p><b>Vous avez une idée pour améliorer ce site Internet&nbsp;? Super, nous avons besoin de vous&nbsp;!</b> <br/>
-					L'intégralité du code source de ce site Internet est disponible sur <a href="https://github.com/netzfreiheit/savetheinternet">github</a> et peut être dupliqué, amélioré, remixé, et renvoyé vers nous.</p>
-				<p>Une chose dont nous avons toujours besoin, et de l'<b>aide pour les traductions</b>. Si vous parlez une langue que nous ne proposons pas encore, merci d'entrer de nous contacter.</p>
-
-				<h3>Espace presse</h3>
-				<p>Notre équipe sera ravie de répondre à toutes les demandes des médias. Envoyez-nous un email à <b><span class="mailcheat" locip="press" domip="savetheinternet.eu">press /à/ savetheinternet.eu</span></b>.</p>
-					<p>Des expert·e·s locaux/ales sont disponibles pour des interviews dans de nombreux pays européens. <br/>Des images sont disponibles <a href="/f/press/press-pics.zip">ici</a> (archive zip).</p>
-
-				<h3>Aidez-nous à relayer notre message</h3>
-				<center>
-					N'hésitez pas à afficher l'une de nos bannières sur votre site Internet&nbsp;:<br/>
-					<a href="/banner.zip">
-						<p>Télécharger les bannières&nbsp;:</p>
-						<img src="/f/press/pics/Full-Banner.png"/>
-						<img src="/f/press/pics/Square-336.png"/>
-					</a>
-				</center>
-
-
-				<h3>Ils parlent de nous</h3>
-				<center>
-					<table>
-						<thead>
-							<tr>
-								<th>Média</th>
-								<th>Date</th>
-								<th>Titre</th>
-								<th>Langue</th>
-							</tr>
-						</thead>
-						<tbody>
-							<tr>
-								<td>technology review (print)</td>
-								<td>02/2014</td>
-								<td>Zutritt nur für VIP Kunden? </td>
-								<td>Allemand</td>
-							</tr>
-							<tr>
-								<td>Radio Dreyeckland</td>
-								<td>24/01/2014</td>
-								<td><a href="https://rdl.de/beitrag/focus-europa-spezial-38-netzneutralit-t">Focus Europa Spezial #38: Eine Debatte über unsere digitale Zukunft und die Netzneutralität in Europa</a></td>
-								<td>Allemand</td>
-							</tr>
-							<tr>
-								<td>Huffington Post</td>
-								<td>22/01/2014</td>
-								<td><a href="http://www.huffingtonpost.de/2014/01/22/internet-ohne-netzneutralitaet_n_4642378.html?utm_hp_ref=tw">Web 3.0: So könnte das Internet ohne Netzneutralität aussehen</a></td>
-								<td>Allemand</td>
-							</tr>
-							<tr>
-								<td>derStandard</td>
-								<td>21/01/2014</td>
-								<td><a href="http://derstandard.at/1389857707853/Google-und-Facebook-dominieren-in-Entwicklungslaendern-den-Internetzugang">Google und Facebook dominieren in Entwicklungsländern den Internetzugang</a></td>
-								<td>Allemand</td>
-							</tr>
-							<tr>
-								<td>FM4 ORF</td>
-								<td>21/01/2014</td>
-								<td><a href="http://fm4.orf.at/stories/1732101/">Internet-Freiheit in Gefahr</a></td>
-								<td>Allemand</td>
-							</tr>
-							<tr>
-								<td>Berliner Zeitung</td>
-								<td>21/01/2014</td>
-								<td><a href="http://www.berliner-zeitung.de/wirtschaft/umstrittene-eu-verordnung-deutschland-droht-zwei-klassen-internet,10808230,25948228.html">Deutschland droht Zwei-Klassen-Internet</a></td>
-								<td>Allemand</td>
-							</tr>
-							<tr>
-								<td>Frankfurter Rundschau</td>
-								<td>21/01/2014</td>
-								<td><a href="http://www.fr-online.de/wirtschaft/internet-gebuehren-datenschutz-zwei-klassen-internet-droht,1472780,25950930.html">Zwei-Klassen-Internet droht</a></td>
-								<td>Allemand</td>
-							</tr>
-							<tr>
-								<td>Unwatched.org</td>
-								<td>20/01/2014</td>
-								<td><a href="http://www.unwatched.org/20140120_SaveTheInternet_Kampagne_zum_Schutz_der_Netzneutralitaet">Jetzt handeln! – SaveTheInternet.eu: Kampagne zum Schutz der Netzneutralität</a></td>
-								<td>Allemand</td>
-							</tr>
-							<tr>
-								<td>Linuxfr.org</td>
-								<td>19/01/2014</td>
-								<td><a href="http://linuxfr.org/news/la-fin-de-la-neutralite-du-net">Internet La fin de la neutralité du net ?</a></td>
-								<td>Français</td>
-							</tr>
-							<tr>
-								<td>Radio Corax</td>
-								<td>17/01/2014</td>
-								<td><a href="http://www.freie-radios.net/61341">Die EU will die Netzneutralität faktisch Abschaffen - Bedeutung und Auswirkungen auf das heutige Internet</a></td>
-								<td>Allemand</td>
-							</tr>
-							<tr>
-								<td>tevac</td>
-								<td>17/01/2014</td>
-								<td><a href="http://www.tevac.com/la-rete-e-in-pericolo-e-tu-puoi-salvarla/">La rete è in pericolo e TU puoi salvarla</a></td>
-								<td>Italien</td>
-							</tr>
-							<tr>
-								<td>Huffington Post</td>
-								<td>16/01/2014</td>
-								<td><a href="http://www.huffingtonpost.de/2014/01/16/netzneutralitat-internet-gerecht-ruf-deinen-abgeordneten-an_n_4612693.html">Netzneutralität - "Ruf deinen Abgeordneten an": So kämpft das Netz für ein gerechtes Internet</a></td>
-								<td>Allemand</td>
-							</tr>
-							<tr>
-								<td>Deutsche Wirtschafts Nachrichten</td>
-								<td>16/01/2014</td>
-								<td><a href="http://deutsche-wirtschafts-nachrichten.de/2014/01/16/kommerz-und-zensur-eu-und-usa-wollen-das-internet-verkaufen/">Kommerz und Zensur: EU und USA wollen das Internet verkaufen</a></td>
-								<td>Allemand</td>
-							</tr>
-							<tr>
-								<td>La Tribune</td>
-								<td>16/01/2014</td>
-								<td><a href="http://www.latribune.fr/technos-medias/20140115trib000809659/dans-la-bataille-internet-contre-telecoms-les-operateurs-gagnent-une-manche.html">Dans la bataille Internet contre télécoms, les opérateurs gagnent une manche</a></td>
-								<td>Français</td>
-							</tr>
-							<tr>
-								<td>Kurier (print)</td>
-								<td>16/01/2014</td>
-								<td><a href="/f/Netzneutralitaet-PRINT-KURIER.pdf">Kampf um das offene Internet</a></td>
-								<td>Allemand</td>
-							</tr>
-							<tr>
-	                <td>Dziennik Internautów</td>
-	                <td>15/01/2014</td>
-	                <td><a href="http://di.com.pl/news/49344,1,Neutralnosc_internetu_przegrywa_w_USA_a_w_UE_walka_trwa_Dolaczysz_sie-Marcin_Maj.html">Neutralność internetu przegrywa w USA, a w UE walka trwa. Dołączysz się?</a></td>
-	                <td>Polonais</td>
-	            </tr>
-	            <tr>
-	                <td>Punto Informatico</td>
-	                <td>15/01/2014</td>
-	                <td><a href="http://punto-informatico.it/3975038/PI/News/usa-scacco-matto-alla-neutralita.aspx">USA, scacco matto alla neutralità?</a></td>
-	                <td>Italien</td>
-	            </tr>
-	            <tr>
-								<td>Huffington Post</td>
-								<td>15/01/2014</td>
-								<td><a href="http://www.huffingtonpost.com/2014/01/15/internet-without-net-neutrality-_n_4604385.html?utm_hp_ref=technology&utm_hp_ref=technology">Web 3.0: What The Internet Could Look Like Without Net Neutrality</a></td>
-								<td>Anglais</td>
-							</tr>
-							<tr>
-								<td>Futurezone.at</td>
-								<td>15/01/2014</td>
-								<td><a href="http://futurezone.at/netzpolitik/kampf-um-das-offene-internet-in-der-eu-und-den-usa/46.193.648">Kampf um das offene Internet in der EU und den USA</a></td>
-								<td>Allemand</td>
-							</tr>
-							<tr>
-								<td>t3n</td>
-								<td>15/01/2014</td>
-								<td><a href="http://t3n.de/news/kampagne-netznetzneutralitaet-eu-522390/">EU entscheidet über Netzneutralität – Fordere deinen Abgeordneten auf, das Internet zu retten!</a></td>
-								<td>Allemand</td>
-							</tr>
-							<tr>
-                <td>Netzpolitik.org</td>
-                <td>14/01/2014</td>
-                <td><a href="https://netzpolitik.org/2014/savetheinternet-eu-kampagne-zur-netzneutralitaet/">SaveTheInternet.eu – Kampagne zur Netzneutralität</a></td>
-                <td>Allemand</td>
-              </tr>
-							<tr>
-								<td>La Quadrature du Net</td>
-								<td>14/01/2014</td>
-								<td><a href="http://www.laquadrature.net/fr/savetheinterneteu-agissons-pour-la-neutralite-du-net">SaveTheInternet.eu : Agissons pour la neutralité du Net !</a></td>
-								<td>Français</td>
-							</tr>
-							<tr>
-								<td>PC INpact</td>
-								<td>14/01/2014</td>
-								<td><a href="http://www.pcinpact.com/news/85352-savetheinternet-eu-neutralite-net-et-priorisation-en-question.htm">SaveTheInternet.eu : la neutralité du net et la « priorisation » en question</a></td>
-								<td>Français</td>
-							</tr>
-							
-							<tr>
-								<td>PC World</td>
-								<td>14/01/2014</td>
-								<td><a href="http://www.pcworld.com/article/2087660/european-civil-rights-groups-join-forces-to-defend-net-neutrality.html">European civil rights groups join forces to defend net neutrality</a></td>
-								<td>Anglais</td>
-							</tr>
-							<tr>
-								<td>Heise</td>
-								<td>14/01/2014</td>
-								<td><a href="http://www.heise.de/netze/meldung/EU-Kommissarin-Kroes-verteidigt-Plaene-zur-Netzneutralitaet-und-Abschaffung-der-Roaminggebuehren-2085357.html">EU-Kommissarin Kroes verteidigt Pläne zur Netzneutralität und Abschaffung der Roaminggebühren</a></td>
-								<td>Allemand</td>
-							</tr>
-							<tr>
-								<td>Reuters</td>
-								<td>14/01/2014</td>
-								<td><a href="http://derstandard.at/1388651026545/US-Gericht-kippt-Regeln-zur-Netzneutralitaet">Schneller gegen Aufpreis: US-Gericht kippt Netzneutralität</a></td>
-								<td>Allemand</td>
-							</tr>
-							<tr>
-								<td>derStandard.at</td>
-								<td>14/01/2014</td>
-								<td><a href="http://derstandard.at/1388650952297/SaveTheInternet-Buergerrechtler-fordern-Netzneutralitaet-per-Gesetz">SaveTheInternet: Bürgerrechtler fordern Netzneutralität per Gesetz</a></td>
-								<td>Allemand</td>
-							</tr>
-							<tr>
-								<td>Logbuch Netzpolitik</td>
-								<td>10/01/2014</td>
-								<td><a href="http://logbuch-netzpolitik.de/lnp089-botschaft-bedeutet-botschaft#t=26:50.530">LNP089 Botschaft bedeutet Botschaft</a></td>
-								<td>Allemand</td>
-							</tr>
-							<tr>
-								<td>N24</td>
-								<td>09/01/2014</td>
-								<td><a href="http://www.n24.de/n24/Kolumnen/Markus-Beckedahl/d/4097296/netzpolitik--ausblick-auf-2014.html">Netzpolitik: Ausblick auf 2014</a></td>
-								<td>Allemand</td>
-							</tr>
-							<tr>
-								<td>panoptykon.org</td>
-								<td>09/01/2014</td>
-								<td><a href="http://panoptykon.org/wiadomosc/powiedz-nie-dla-internetu-dwoch-predkosci">Powiedz: NIE dla Internetu dwóch prędkości!</a></td>
-								<td>Polonais</td>
-							</tr>
-							<tr>
-								<td>ZDF</td>
-								<td>09/01/2014</td>
-								<td><a href="http://blog.zdf.de/hyperland/2014/01/letzte-rettung-fuer-die-netzneutralitaet/">Letzte Rettung für die Netzneutralität?</a></td>
-								<td>Allemand</td>
-							</tr>
-							<tr>
-								<td>TAZ</td>
-								<td>08/01/2014</td>
-								<td><a href="http://taz.de/Internetaktivist-ueber-Netzneutralitaet/!130473/">Internetaktivist über Netzneutralität: „Uns bleibt nur noch sehr wenig Zeit“</a></td>
-								<td>Allemand</td>
-							</tr>
-							<tr>
-								<td>Reddit</td>
-								<td>08/01/2014</td>
-								<td><a href="http://w3.reddit.com/domain/savetheinternet.eu/">savetheinternet.eu on reddit.com</a></td>
-								<td>Anglais</td>
-							</tr>
-							<tr>
-								<td>Gulli.com</td>
-								<td>28/12/2013</td>
-								<td><a href="http://www.gulli.com/news/23039-30c3-der-kampf-um-die-netzneutralitaet-2013-12-28">30C3: Der Kampf um die Netzneutralität</a></td>
-								<td>Allemand</td>
-							</tr>
-							<tr>
-								<td>30c3 Talk</td>
-								<td>27/12/2013</td>
-								<td><a href="http://media.ccc.de/browse/congress/2013/30C3_-_5348_-_de_-_saal_2_-_201312272145_-_der_kampf_um_netzneutralitat_-_markus_beckedahl_-_thomas_lohninger.html">30C3: Der Kampf um Netzneutralität – Wer kontrolliert das Netz?</a></td>
-								<td>Allemand</td>
-							</tr>
-						</tbody>
-					</table>
-				</center>
-				<h3>Vie privée</h3>
-				<p>Nous ne récoltons aucune informations personnelles sur ce site Internet à l'aide de <a href="http://piwik.org/privacy-policy/">Piwik</a>, un logiciel d'analyse web respectueux de la vie privée.</p>
-			</div>
-
-			<div class=shareit>
-					
-					<h3>… et faites passer le mot&nbsp;:</h3>
-					<div class=hmid>
-						<a href="http://www.facebook.com/sharer/sharer.php?s=100&p[url]=http://www.savetheinternet.eu/&p[images][0]=http://www.savetheinternet.eu/img/thumbnail.png&p[title]=Help%20Save%20the%20Internet&p[summary]=Your%20freedom%20online%20is%20threatened%20by%20EU%20proposals.%20The%20fight%20for%20an%20open%20Internet%20is%20happening%20right%20now%20in%20Brussels." class="sharebt sm-fb"><img src="/img/share_i_fb.png" class=vmid> <span class=vmid>Facebook</span></a>
-						<a href="http://twitter.com/home?status=Help%20save%20the%20internet.%20Tell%20your%20politician%20to%20safeguard%20net%20neutrality.%20http://www.savetheinternet.eu/%20%23ConnectedContinent%20#SaveTheInternetEU" class="sharebt sm-tw"><img src="/img/share_i_tw.png" class=vmid> <span class=vmid>Twitter</span></a>
-						<a href="https://plus.google.com/share?url=http://www.savetheinternet.eu/" class="sharebt sm-gp"><img src="/img/share_i_gp.png" class=vmid> <span class=vmid>Google+</span></a>
+						<p>Si vous n'êtes pas à l'aise au téléphone, vous pouvez aussi <b>contacter votre eurodéputé·e par email</b>. Vous pouvez trouver leurs adresses dans le <a href="#act">widget</a> mail ci-dessus ou sur <a rel="nofollow" class="external text" href="http://memopol.lqdn.fr/">Memopol.</a>.</p>
+						<p>Certains proposent parfois d'envoyer des emails génériques à tou·te·s les eurodéputé·e·s (y compris à ceux et celles qui ne votent pas sur le sujet en question). Nous estimons que ces emails sont inutiles, voire contre productifs. Les député·e·s et leurs assistant·e·s savent aussi bien que vous utiliser des filtres anti-spam, et ces messages finissent rapidement dans leur dossier « spam ». Les emails génériques donnent l'impression que vous n'accordez pas suffisamment d'importance au sujet pour prendre le temps d'envoyer un message personnalisé, et ne reflètent même pas le nombre de personnes s'impliquant (une seule personne peut envoyer le même message plusieurs fois). Pire, ces emails augmentent le risque que les élu·e·s ne lisent plus les messages personnalisés concernant ce sujet, et finalement le déservent votre action. Si vous souhaitez vraiment ajouter votre nom à un texte déjà écrit, vous feriez mieux de signer une pétition.</p>
+						<p>La meilleure solution est d'envoyer un email reflétant votre propre approche et vos connaissances du sujet (souvenez-vous : personne n'attend de vous que vous soyez un·e expert·e, seulement un·e citoyen·ne concerné·e) et, si possible, adapté·e aux positions du groupe de l'élu·e.</p>
+						<div class="moaromg">
+							<a href="#act" class="omgbutton">
+								<img src="/img/phoneicon.png" class="vmid"> 
+								<span class="vmid">Appelez votre eurodéputé·e sans attendre !</span>
+							</a>
+						</div>
+						
 					</div>
 				</div>
-			</div>
+			</section>
+			
+			<span id="contact" class="anchor"></span>
+			<section class="widesec">
+				<div class="contentwidth"> 
+					<div class="indentarea2">
+						
+						<h3>Contact</h3>
+						<p>Vous pouvez nous contacter à <b><span class="mailcheat" locip="info" domip="savetheinternet.eu">info /chez/ savetheinternet.eu</span></b></p>
+						
+						<p><b>Vous avez une idée pour améliorer ce site Internet ? Super, nous avons besoin de vous !</b> <br/>
+							L'intégralité du code source de ce site web est disponible sur <a href="https://github.com/netzfreiheit/savetheinternet">Github</a> et peut être dupliqué, amélioré, remixé, et renvoyé vers nous.</p>
+						<p>Une chose dont nous avons toujours besoin, et de l'<strong>aide pour les traductions</strong>. Si vous parlez une langue que nous ne proposons pas encore, merci d'entrer de nous contacter.</p>
+						<h3>Espace presse</h3>
+						<p>Notre équipe sera ravie de répondre à toutes les demandes des médias. Envoyez-nous un email à <b><span class="mailcheat" locip="press" domip="savetheinternet.eu">press /à/ savetheinternet.eu</span></b>.</p>
+						<p>Des expert·e·s locaux/ales sont disponibles pour des interviews dans de nombreux pays européens.<br />
+							Des images sont disponibles <a href="/f/press/press-pics.zip">ici</a> (archive zip).</p>
+						
+						<h3>Aidez-nous à relayer notre message</h3>
+						<center>
+							N'hésitez pas à afficher l'une de nos bannières sur votre site Internet :<br/>
+							<a href="/banner.zip">
+								<p>Télécharger les bannières :</p>
+								<img src="/f/press/pics/Full-Banner.png"/>
+								<img src="/f/press/pics/Square-336.png"/>
+							</a>
+						</center>
+						
+						<h3>Ils parlent de nous</h3>
+						<center>
+							<table>
+								<thead>
+									<tr>
+										<th>Média</th>
+										<th>Date</th>
+										<th>Titre</th>
+										<th>Langue</th>
+									</tr>
+								</thead>
+								<tbody>
+									<tr>
+										<td>technology review (print)</td>
+										<td>02/2014</td>
+										<td>Zutritt nur für VIP Kunden? </td>
+										<td>Allemand</td>
+									</tr>
+									<tr>
+										<td>Radio Dreyeckland</td>
+										<td>24/01/2014</td>
+										<td><a href="https://rdl.de/beitrag/focus-europa-spezial-38-netzneutralit-t">Focus Europa Spezial #38: Eine Debatte über unsere digitale Zukunft und die Netzneutralität in Europa</a></td>
+										<td>Allemand</td>
+									</tr>
+									<tr>
+										<td>Huffington Post</td>
+										<td>22/01/2014</td>
+										<td><a href="http://www.huffingtonpost.de/2014/01/22/internet-ohne-netzneutralitaet_n_4642378.html?utm_hp_ref=tw">Web 3.0: So könnte das Internet ohne Netzneutralität aussehen</a></td>
+										<td>Allemand</td>
+									</tr>
+									<tr>
+										<td>derStandard</td>
+										<td>21/01/2014</td>
+										<td><a href="http://derstandard.at/1389857707853/Google-und-Facebook-dominieren-in-Entwicklungslaendern-den-Internetzugang">Google und Facebook dominieren in Entwicklungsländern den Internetzugang</a></td>
+										<td>Allemand</td>
+									</tr>
+									<tr>
+										<td>FM4 ORF</td>
+										<td>21/01/2014</td>
+										<td><a href="http://fm4.orf.at/stories/1732101/">Internet-Freiheit in Gefahr</a></td>
+										<td>Allemand</td>
+									</tr>
+									<tr>
+										<td>Berliner Zeitung</td>
+										<td>21/01/2014</td>
+										<td><a href="http://www.berliner-zeitung.de/wirtschaft/umstrittene-eu-verordnung-deutschland-droht-zwei-klassen-internet,10808230,25948228.html">Deutschland droht Zwei-Klassen-Internet</a></td>
+										<td>Allemand</td>
+									</tr>
+									<tr>
+										<td>Frankfurter Rundschau</td>
+										<td>21/01/2014</td>
+										<td><a href="http://www.fr-online.de/wirtschaft/internet-gebuehren-datenschutz-zwei-klassen-internet-droht,1472780,25950930.html">Zwei-Klassen-Internet droht</a></td>
+										<td>Allemand</td>
+									</tr>
+									<tr>
+										<td>Unwatched.org</td>
+										<td>20/01/2014</td>
+										<td><a href="http://www.unwatched.org/20140120_SaveTheInternet_Kampagne_zum_Schutz_der_Netzneutralitaet">Jetzt handeln! – SaveTheInternet.eu: Kampagne zum Schutz der Netzneutralität</a></td>
+										<td>Allemand</td>
+									</tr>
+									<tr>
+										<td>Linuxfr.org</td>
+										<td>19/01/2014</td>
+										<td><a href="http://linuxfr.org/news/la-fin-de-la-neutralite-du-net">Internet La fin de la neutralité du net ?</a></td>
+										<td>Français</td>
+									</tr>
+									<tr>
+										<td>Radio Corax</td>
+										<td>17/01/2014</td>
+										<td><a href="http://www.freie-radios.net/61341">Die EU will die Netzneutralität faktisch Abschaffen - Bedeutung und Auswirkungen auf das heutige Internet</a></td>
+										<td>Allemand</td>
+									</tr>
+									<tr>
+										<td>tevac</td>
+										<td>17/01/2014</td>
+										<td><a href="http://www.tevac.com/la-rete-e-in-pericolo-e-tu-puoi-salvarla/">La rete è in pericolo e TU puoi salvarla</a></td>
+										<td>Italien</td>
+									</tr>
+									<tr>
+										<td>Huffington Post</td>
+										<td>16/01/2014</td>
+										<td><a href="http://www.huffingtonpost.de/2014/01/16/netzneutralitat-internet-gerecht-ruf-deinen-abgeordneten-an_n_4612693.html">Netzneutralität - "Ruf deinen Abgeordneten an": So kämpft das Netz für ein gerechtes Internet</a></td>
+										<td>Allemand</td>
+									</tr>
+									<tr>
+										<td>Deutsche Wirtschafts Nachrichten</td>
+										<td>16/01/2014</td>
+										<td><a href="http://deutsche-wirtschafts-nachrichten.de/2014/01/16/kommerz-und-zensur-eu-und-usa-wollen-das-internet-verkaufen/">Kommerz und Zensur: EU und USA wollen das Internet verkaufen</a></td>
+										<td>Allemand</td>
+									</tr>
+									<tr>
+										<td>La Tribune</td>
+										<td>16/01/2014</td>
+										<td><a href="http://www.latribune.fr/technos-medias/20140115trib000809659/dans-la-bataille-internet-contre-telecoms-les-operateurs-gagnent-une-manche.html">Dans la bataille Internet contre télécoms, les opérateurs gagnent une manche</a></td>
+										<td>Français</td>
+									</tr>
+									<tr>
+										<td>Kurier (print)</td>
+										<td>16/01/2014</td>
+										<td><a href="/f/Netzneutralitaet-PRINT-KURIER.pdf">Kampf um das offene Internet</a></td>
+										<td>Allemand</td>
+									</tr>
+									<tr>
+										<td>Dziennik Internautów</td>
+										<td>15/01/2014</td>
+										<td><a href="http://di.com.pl/news/49344,1,Neutralnosc_internetu_przegrywa_w_USA_a_w_UE_walka_trwa_Dolaczysz_sie-Marcin_Maj.html">Neutralność internetu przegrywa w USA, a w UE walka trwa. Dołączysz się?</a></td>
+										<td>Polonais</td>
+									</tr>
+									<tr>
+										<td>Punto Informatico</td>
+										<td>15/01/2014</td>
+										<td><a href="http://punto-informatico.it/3975038/PI/News/usa-scacco-matto-alla-neutralita.aspx">USA, scacco matto alla neutralità?</a></td>
+										<td>Italien</td>
+									</tr>
+									<tr>
+										<td>Huffington Post</td>
+										<td>15/01/2014</td>
+										<td><a href="http://www.huffingtonpost.com/2014/01/15/internet-without-net-neutrality-_n_4604385.html?utm_hp_ref=technology&utm_hp_ref=technology">Web 3.0: What The Internet Could Look Like Without Net Neutrality</a></td>
+										<td>Anglais</td>
+									</tr>
+									<tr>
+										<td>Futurezone.at</td>
+										<td>15/01/2014</td>
+										<td><a href="http://futurezone.at/netzpolitik/kampf-um-das-offene-internet-in-der-eu-und-den-usa/46.193.648">Kampf um das offene Internet in der EU und den USA</a></td>
+										<td>Allemand</td>
+									</tr>
+									<tr>
+										<td>t3n</td>
+										<td>15/01/2014</td>
+										<td><a href="http://t3n.de/news/kampagne-netznetzneutralitaet-eu-522390/">EU entscheidet über Netzneutralität – Fordere deinen Abgeordneten auf, das Internet zu retten!</a></td>
+										<td>Allemand</td>
+									</tr>
+									<tr>
+										<td>Netzpolitik.org</td>
+										<td>14/01/2014</td>
+										<td><a href="https://netzpolitik.org/2014/savetheinternet-eu-kampagne-zur-netzneutralitaet/">SaveTheInternet.eu – Kampagne zur Netzneutralität</a></td>
+										<td>Allemand</td>
+									</tr>
+									<tr>
+										<td>La Quadrature du Net</td>
+										<td>14/01/2014</td>
+										<td><a href="http://www.laquadrature.net/fr/savetheinterneteu-agissons-pour-la-neutralite-du-net">SaveTheInternet.eu : Agissons pour la neutralité du Net !</a></td>
+										<td>Français</td>
+									</tr>
+									<tr>
+										<td>PC INpact</td>
+										<td>14/01/2014</td>
+										<td><a href="http://www.pcinpact.com/news/85352-savetheinternet-eu-neutralite-net-et-priorisation-en-question.htm">SaveTheInternet.eu : la neutralité du net et la « priorisation » en question</a></td>
+										<td>Français</td>
+									</tr>									
+									<tr>
+										<td>PC World</td>
+										<td>14/01/2014</td>
+										<td><a href="http://www.pcworld.com/article/2087660/european-civil-rights-groups-join-forces-to-defend-net-neutrality.html">European civil rights groups join forces to defend net neutrality</a></td>
+										<td>Anglais</td>
+									</tr>
+									<tr>
+										<td>Heise</td>
+										<td>14/01/2014</td>
+										<td><a href="http://www.heise.de/netze/meldung/EU-Kommissarin-Kroes-verteidigt-Plaene-zur-Netzneutralitaet-und-Abschaffung-der-Roaminggebuehren-2085357.html">EU-Kommissarin Kroes verteidigt Pläne zur Netzneutralität und Abschaffung der Roaminggebühren</a></td>
+										<td>Allemand</td>
+									</tr>
+									<tr>
+										<td>Reuters</td>
+										<td>14/01/2014</td>
+										<td><a href="http://derstandard.at/1388651026545/US-Gericht-kippt-Regeln-zur-Netzneutralitaet">Schneller gegen Aufpreis: US-Gericht kippt Netzneutralität</a></td>
+										<td>Allemand</td>
+									</tr>
+									<tr>
+										<td>derStandard.at</td>
+										<td>14/01/2014</td>
+										<td><a href="http://derstandard.at/1388650952297/SaveTheInternet-Buergerrechtler-fordern-Netzneutralitaet-per-Gesetz">SaveTheInternet: Bürgerrechtler fordern Netzneutralität per Gesetz</a></td>
+										<td>Allemand</td>
+									</tr>
+									<tr>
+										<td>Logbuch Netzpolitik</td>
+										<td>10/01/2014</td>
+										<td><a href="http://logbuch-netzpolitik.de/lnp089-botschaft-bedeutet-botschaft#t=26:50.530">LNP089 Botschaft bedeutet Botschaft</a></td>
+										<td>Allemand</td>
+									</tr>
+									<tr>
+										<td>N24</td>
+										<td>09/01/2014</td>
+										<td><a href="http://www.n24.de/n24/Kolumnen/Markus-Beckedahl/d/4097296/netzpolitik--ausblick-auf-2014.html">Netzpolitik: Ausblick auf 2014</a></td>
+										<td>Allemand</td>
+									</tr>
+									<tr>
+										<td>panoptykon.org</td>
+										<td>09/01/2014</td>
+										<td><a href="http://panoptykon.org/wiadomosc/powiedz-nie-dla-internetu-dwoch-predkosci">Powiedz: NIE dla Internetu dwóch prędkości!</a></td>
+										<td>Polonais</td>
+									</tr>
+									<tr>
+										<td>ZDF</td>
+										<td>09/01/2014</td>
+										<td><a href="http://blog.zdf.de/hyperland/2014/01/letzte-rettung-fuer-die-netzneutralitaet/">Letzte Rettung für die Netzneutralität?</a></td>
+										<td>Allemand</td>
+									</tr>
+									<tr>
+										<td>TAZ</td>
+										<td>08/01/2014</td>
+										<td><a href="http://taz.de/Internetaktivist-ueber-Netzneutralitaet/!130473/">Internetaktivist über Netzneutralität: „Uns bleibt nur noch sehr wenig Zeit“</a></td>
+										<td>Allemand</td>
+									</tr>
+									<tr>
+										<td>Reddit</td>
+										<td>08/01/2014</td>
+										<td><a href="http://w3.reddit.com/domain/savetheinternet.eu/">savetheinternet.eu on reddit.com</a></td>
+										<td>Anglais</td>
+									</tr>
+									<tr>
+										<td>Gulli.com</td>
+										<td>28/12/2013</td>
+										<td><a href="http://www.gulli.com/news/23039-30c3-der-kampf-um-die-netzneutralitaet-2013-12-28">30C3: Der Kampf um die Netzneutralität</a></td>
+										<td>Allemand</td>
+									</tr>
+									<tr>
+										<td>30c3 Talk</td>
+										<td>27/12/2013</td>
+										<td><a href="http://media.ccc.de/browse/congress/2013/30C3_-_5348_-_de_-_saal_2_-_201312272145_-_der_kampf_um_netzneutralitat_-_markus_beckedahl_-_thomas_lohninger.html">30C3: Der Kampf um Netzneutralität – Wer kontrolliert das Netz?</a></td>
+										<td>Allemand</td>
+									</tr>
+								</tbody>
+							</table>
+						</center>
+						<h3>Vie privée</h3>
+						<p>Nous ne récoltons aucune informations personnelles sur ce site Internet à l'aide de <a href="http://piwik.org/privacy-policy/">Piwik</a>, un logiciel d'analyse web respectueux de la vie privée.</p>
+					</div>
+					
+					<div class="shareit">
+						
+						<h3>… et faites passer le mot :</h3>
+						<div class="hmid">
+							<a href="http://www.facebook.com/sharer/sharer.php?s=100&p[url]=http://www.savetheinternet.eu/&p[images][0]=http://www.savetheinternet.eu/img/thumbnail.png&p[title]=Help%20Save%20the%20Internet&p[summary]=Your%20freedom%20online%20is%20threatened%20by%20EU%20proposals.%20The%20fight%20for%20an%20open%20Internet%20is%20happening%20right%20now%20in%20Brussels." class="sharebt sm-fb"><img src="/img/share_i_fb.png" class=vmid> <span class=vmid>Facebook</span></a>
+							<a href="http://twitter.com/home?status=Help%20save%20the%20internet.%20Tell%20your%20politician%20to%20safeguard%20net%20neutrality.%20http://www.savetheinternet.eu/%20%23ConnectedContinent%20#SaveTheInternetEU" class="sharebt sm-tw"><img src="/img/share_i_tw.png" class=vmid> <span class=vmid>Twitter</span></a>
+							<a href="https://plus.google.com/share?url=http://www.savetheinternet.eu/" class="sharebt sm-gp"><img src="/img/share_i_gp.png" class=vmid> <span class=vmid>Google+</span></a>
+						</div>
+					</div>
+				</div>
+			</section>
+			
+			<footer class="widesec">
+				<div class="contentwidth">
+					<p style="text-align:center;">Nous sommes des citoyen·ne·s concerné·e·s, appartenant à diverses ONG européennes, et soucieux/euses de défendre les libertés publiques dans le monde numérique.<br> 
+						Cette campagne est menée par :</p>
+					<ul class="footerlogos">
+						<li>
+							<a href="https://netzfreiheit.org/">
+								<img src="/img/ifnf.png" /><br>
+								Initiative für Netzfreiheit (Autriche)
+							</a>
+						</li>
+						<li>
+							<a href="https://edri.org/">
+								<img src="/img/edri.png" /><br>
+								European Digital Rights (Bruxelles)
+							</a>
+						</li>
+						<li>
+							<a href="https://digitalegesellschaft.de">
+								<img src="/img/digiges.png" /><br>
+								Digitale Gesellschaft (Allemagne)
+							</a>
+						</li>
+						<li>
+							<a href="https://www.accessnow.org">
+								<img src="/img/access.png" /><br>
+								Access Now (Bruxelles)
+							</a>
+						</li>
+						<li>
+							<a href="https://www.laquadrature.net/">
+								<img src="/img/lqdn.png" /><br>
+								La Quadrature du Net (France)
+							</a>
+						</li>
+						<li>
+							<a href="https://www.bof.nl/">
+								<img src="/img/bof.png" /><br>
+								Bits of Freedom (Pays-Bas)
+							</a>
+						</li>
+						<li>
+							<a href="http://www.goveto.org/">
+								<img src="/img/goveto.png" /><br>
+								GoVeto (Allemagne)
+							</a>
+						</li>
+						<li>
+							<a href="http://en.rsf.org/">
+								<img src="/img/reporters_without_borders.png" /><br>
+								Reporters Without Borders
+							</a>
+						</li>
+					</ul>
+				</div>
+				<div class="clr"></div>
+			</footer>	
 		</div>
-	</section>
-	
-	<footer class=widesec>
-		<div class=contentwidth>
-			<p style="text-align:center;">Nous sommes des citoyen·ne·s concerné·e·s, appartenant à diverses ONG européennes, et soucieux/euses de défendre les libertés publiques dans le monde numérique.<br> 
-			Cette campagne est menée par&nbsp;:</p>
-			<ul class=footerlogos>
-			<li>
-				<a href="https://netzfreiheit.org/">
-					<img src="/img/ifnf.png" /><br>
-					Initiative für Netzfreiheit (Autriche)
-				</a>
-			</li>
-			<li>
-				<a href="https://edri.org/">
-					<img src="/img/edri.png" /><br>
-					European Digital Rights (Bruxelles)
-				</a>
-			</li>
-			<li>
-				<a href="https://digitalegesellschaft.de">
-					<img src="/img/digiges.png" /><br>
-					Digitale Gesellschaft (Allemagne)
-				</a>
-			</li>
-			<li>
-				<a href="https://www.accessnow.org">
-					<img src="/img/access.png" /><br>
-					Access Now (Bruxelles)
-				</a>
-			</li>
-			<li>
-				<a href="https://www.laquadrature.net/">
-					<img src="/img/lqdn.png" /><br>
-					La Quadrature du Net (France)
-				</a>
-			</li>
-			<li>
-				<a href="https://www.bof.nl/">
-					<img src="/img/bof.png" /><br>
-					Bits of Freedom (Pays-Bas)
-				</a>
-			</li>
-			<li>
-				<a href="http://www.goveto.org/">
-					<img src="/img/goveto.png" /><br>
-					GoVeto (Allemagne)
-				</a>
-			</li>
-			<li>
-				<a href="http://en.rsf.org/">
-					<img src="/img/reporters_without_borders.png" /><br>
-					Reporters Without Borders
-				</a>
-			</li>
-			</ul>
-		</div>
-	<div class=clr></div>
-	</footer>
-
-</div>
-
-<!-- Piwik -->
-<script type="text/javascript">
- var _paq = _paq || [];
- _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
- _paq.push(["setCookieDomain", "*.savetheinternet.eu"]);
- _paq.push(["setDomains", ["*.savetheinternet.eu"]]);
- _paq.push(["setDoNotTrack", true]);
- _paq.push(["trackPageView"]);
- _paq.push(["enableLinkTracking"]);
-
- (function() {
-   var u=(("https:" == document.location.protocol) ? "https" : "http")
-+ "://piwik.netzfreiheit.org/";
-   _paq.push(["setTrackerUrl", u+"piwik.php"]);
-   _paq.push(["setSiteId", "11"]);
-   var d=document, g=d.createElement("script"),
-s=d.getElementsByTagName("script")[0]; g.type="text/javascript";
-   g.defer=true; g.async=true; g.src=u+"piwik.js";
-s.parentNode.insertBefore(g,s);
- })();
-</script>
- <!-- End Piwik Code -->
-
-</body>
+		<!-- Piwik -->
+		<script type="text/javascript">
+			var _paq = _paq || [];
+			_paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+			_paq.push(["setCookieDomain", "*.savetheinternet.eu"]);
+			_paq.push(["setDomains", ["*.savetheinternet.eu"]]);
+			_paq.push(["setDoNotTrack", true]);
+			_paq.push(["trackPageView"]);
+			_paq.push(["enableLinkTracking"]);
+			
+			(function() {
+			var u=(("https:" == document.location.protocol) ? "https" : "http")
+			+ "://piwik.netzfreiheit.org/";
+			_paq.push(["setTrackerUrl", u+"piwik.php"]);
+			_paq.push(["setSiteId", "11"]);
+			var d=document, g=d.createElement("script"),
+			s=d.getElementsByTagName("script")[0]; g.type="text/javascript";
+			g.defer=true; g.async=true; g.src=u+"piwik.js";
+			s.parentNode.insertBefore(g,s);
+			})();
+		</script>
+		<!-- End Piwik Code -->		
+	</body>
 </html>


### PR DESCRIPTION
Uniformisation : si l’on dit « député(e) » dans le dialogue, autant vraiment utiliser du langage non-sexiste dans tout le texte. De plus la mise entre parenthèses — en plus d’être graphiquement lourde — peut participer à réduire le féminin par rapport au masculin : les points médians, plus discrets et plus égalitaires, sont alors préférés.
Certaines formes sont lourdes, et nécessitent peut-être une révision ultérieure pour trouver un moyen plus léger mais linguistiquement moins sexiste d’exprimer un sens équivalent.