### PR TITLE
redirect http2https

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,4 +1,6 @@
 RewriteEngine On
+RewriteCond %{HTTPS} off
+RewriteRule (.*) https://%{HTTP_HOST}%{REQUEST_URI}
 RewriteCond %{HTTP:Accept-Language} ^de [NC]
 RewriteRule ^$ /de/ [L,R=301]
 RewriteCond %{HTTP:Accept-Language} ^pl [NC]


### PR DESCRIPTION
Forced redirection from http to https.
Works by default only on httpd and apache (& webserver supporting .htaccess by default)
