### PR TITLE
Aspell scanned for typos; clearing 'web' word, kind of redundancy since ...

### DIFF
--- a/sq/index.html
+++ b/sq/index.html
@@ -84,7 +84,7 @@
 					Mundet që të paguani më shumë për më pak shërbime internet
 				</h2></div>
 				<div class=desctext>
-					Komisioni Europian ka propozuar një Akt Rregullator që do t'u lejonte ofruesve të Internetit të zbatojnë çmime shtesë për çdo shërbim në linjë. I quajnë "shërbime të specializuara", dhe kjo mund të shpinte në një internet me dy shpejtësi, ku vetëm kompanitë me xhepat plot mund t'ia dalin të pozicionohen në korsinë e shpejtë, duke na lënë targën krejt ne të tjerëve.
+					Komisioni Europian ka propozuar një Akt Rregullator që do t’u lejonte ofruesve të Internetit të zbatojnë çmime shtesë për çdo shërbim në linjë. I quajnë "shërbime të specializuara", dhe kjo mund të shpinte në një internet me dy shpejtësi, ku vetëm kompanitë me xhepat plot mund t’ia dalin të pozicionohen në korsinë e shpejtë, duke na lënë targën krejt ne të tjerëve.
 				</div>
 				<div class=clr></div>
 				<div class=whypic id=whypic1><img id=whypicimg1 src="/img/specialized_services.png"></div>
@@ -99,7 +99,7 @@
 			<div class=descmain>
 				<img src="/img/provider_control.png" style="float:right; margin: -40px 0 -30px;"> 
 				<div class=headlinewrp><h2 class=headline id=whyheadline2>
-					Ofruesit e Internetit do të vendosin ç'mund të bëni dhe s'bëni dot në linjë
+					Ofruesit e Internetit do të vendosin ç’mund të bëni dhe s’bëni dot në linjë
 				</h2></div>
 				<div class=desctext style="max-width:31em;">
 					Ofruesit e Internetit do të jenë në gjendje të bllokojnë lëndë pa asnjë shqyrtim gjyqësor, veç në u përmirësoftë Akti Rregullator. Ofruesit e Shërbimeve Internet nuk duhet të jenë policët e internetit. Atyre nuk u duhet lejuar të vendosin çfarë lënde mund të përdorni dhe çfarë jo.
@@ -117,10 +117,10 @@
 			<div class=descmain>
 				<div class=whypic id=whypic3><img src="/img/internet_monopoly.png"></div>
 				<div class=headlinewrp><h2 class=headline  id=whyheadline3 >
-					Liria e fjalës do të kufizohet dhe novacionit do t'i zihet fryma
+					Liria e fjalës do të kufizohet dhe novacionit do t’i zihet fryma
 				</h2></div>
 				<div class=desctext id=whytext3>
-					Deri sot, kompanitë e mëdha si Microsoft-i dhe Facebook-u janë në të njëjtën shkallë përparësie si blogjet apo podkastet tona. Por nëse nuk ndreqet përkufizimi i "shërbimeve të specializuara", këto shoqëri do të jenë në korsinë e shpejtë të autostradës së të dhënave, duke i lënë kompanitë e sapokrijuara dhe sajtet web jokomerciale, fjala vjen Wikipedia-n, në korsinë e ngadaltë.
+					Deri sot, kompanitë e mëdha si Microsoft-i dhe Facebook-u janë në të njëjtën shkallë përparësie si blogjet apo podkastet tona. Por nëse nuk ndreqet përkufizimi i "shërbimeve të specializuara", këto shoqëri do të jenë në korsinë e shpejtë të autostradës së të dhënave, duke i lënë kompanitë e sapokrijuara dhe sajtet jokomerciale, fjala vjen Wikipedia-n, në korsinë e ngadaltë.
 				</div>
 				<div class=clr></div>
 			</div>
@@ -194,14 +194,14 @@
 
 				<iframe width="720" height="420" src="//www.youtube-nocookie.com/embed/HCUg5A-ZAw0" frameborder="0" allowfullscreen></iframe>
 
-				<p>Suksesi në vazhdimësi i internetit bazohet në tre parime themelore. Së pari, parimi skaj-më-skaj, i cili siguron që krejt pikat e rrjetit duhet të jenë në gjendje të lidhen me krejt pikat e tjera te rrjeti. Së dyti, parimi i përpjekjes më të mirë, i cili garanton që krejt ofruesit e internetit duhet të bëjnë më të mirën e mundshme për të dërgua trafik nga një pikë në një tjetër me sa më efektshmëri që të mundet. E fundit, por jo për nga rëndësia, parimi i risimit pa u dashur leje, që pohon se gjithkush duhet të jetë në gjendje të kryejë risi, pa iu dashur leje nga asnjë person apo njësi. Këto parime mund të përkufizohen së toku si asnjanësi në rrjet, e cila është themelore për të siguruar hedhjen shtat dhe risimet në sektorin TIK, dhe për t'i patur të paprekshme vlerat bazë të internetit për demokracinë dhe lirinë e komunikimit.</p>
+				<p>Suksesi në vazhdimësi i internetit bazohet në tre parime themelore. Së pari, parimi skaj-më-skaj, i cili siguron që krejt pikat e rrjetit duhet të jenë në gjendje të lidhen me krejt pikat e tjera te rrjeti. Së dyti, parimi i përpjekjes më të mirë, i cili garanton që krejt ofruesit e internetit duhet të bëjnë më të mirën e mundshme për të dërgua trafik nga një pikë në një tjetër me sa më efektshmëri që të mundet. E fundit, por jo për nga rëndësia, parimi i risimit pa u dashur leje, që pohon se gjithkush duhet të jetë në gjendje të kryejë risi, pa iu dashur leje nga asnjë person apo njësi. Këto parime mund të përkufizohen së toku si asnjanësi në rrjet, e cila është themelore për të siguruar hedhjen shtat dhe risimet në sektorin TIK, dhe për t’i patur të paprekshme vlerat bazë të internetit për demokracinë dhe lirinë e komunikimit.</p>
  
  				<p>Asnjanësia në rrjet do të thotë që krejt trafiku në internet të trajtohet në mënyrë të barabartë, pavarësisht origjinës, marrësit, dërguesit, llojit të lëndës apo mjeteve (p.sh. pajisje apo protokolle) të përdorura për transmetimin e paketeve. Çfarëdo shmangie nga ky parim (fjala vjen, për arsye mbingarkimi të trafikut) duhet të jetë e nevojshme, e maatur, e përkohshme, me objektiv të qartë, transparente, dhe në përputhje me ligjet përkatëse. Asnjanësia në rrjet është parimi udhëheqës i internetit të hapur. Ka vlerë themelore të sigurohemi se interneti do të mbetet një platformë për të gëzuar të drejtat e njeriut dhe risitë. Asnjanësia në rrjet do të thotë që krejt trafiku në internet të trajtohet në mënyrë të barabartë, pavarësisht origjinës, llojit të lëndë apo mjeteve. </p>
 
 				<p>Komisioni Europian pat premtuar se në Aktin Rregullator do të ruajë të paprekshëm parimin themelor të internetit, por teksti i propozuar nuk arrin të ofrojë asnjanësi në rrjet. Nëse nuk hidheni në veprim për të ndihmuar Parlamentin Europian ta ndreqë tekstin, interneti shumë shpejt do të ngjajë pak a shumë me televizionin kabllor, ku operatori i shërbimit tuaj ka kontroll tërësor mbi atë çka mund të përdorni në linjë, madje duke ju vënë edhe çmime ekstra për disa shërbime. </p>
-  
+ 
 
-				<p>Na duhet ndihma juaj për t'u thënë parlamentarëve të mbrojnë internetin e hapur dhe asnjanës - u thoni të mbrojnë asnjanësi në rrjet!</p>
+				<p>Na duhet ndihma juaj për t’u thënë parlamentarëve të mbrojnë internetin e hapur dhe asnjanës - u thoni të mbrojnë asnjanësi në rrjet!</p>
 
 				<p>Disa gjëra të tjera që mund të donit të dini mbi asnjanësi në rrjet:</p>
 				
@@ -222,25 +222,25 @@
 		<div class=contentwidth>
 			<div class=indentarea2>
 
-				<h3>Ç'po ndodh në BE?</h3>
-				<p>Neelie Kroes, komisionerja për Axhendën Dixhitale, premtoi se do të mbronte asnjanësinë në rrjet. Megjithatë, gjatë pakë viteve të kaluara pozicioni i saj ka ndryshuar në mënyrë domethënëse në kah të kundërt. <a href="http://ec.europa.eu/information_society/newsroom/cf/dae/document.cfm?doc_id=2734">Propozimi i saj për një Akt Rregullator Tregu Unik Telekomesh</a> e ripohon këtë. Teksa e mirëpresim dëshirën për të shenjtëruar asnjanësinë e rrjetit në ligjet e vendeve të BE-së, propozimi nuk arrin të përmbushë premtimin për asnjanësi në rrjet, ngaqë përmban një numër të çarash problematike. Sidoqoftë, vetë teksti nuk është larg të saktit. Me përmirësimet e duhura, Bashkimi Europian do të mundte ta nguliste në legjislacion asnjanësinë e rrjetit. Propozimi tani është në duart e parlamentit dhe do të shqyrtohet nga disa komisione, me atë të Industrisë, Kërkimeve dhe Energjisë (ITRE) si i ngarkuari me dosjen. Modifikimet e propozuara në disa komisione për fat të keq i kanë përkeqësuar problemet në propozimin e Komisionit. Për më tepër, para legjislacionit ka një plan kohor shumë strikt, ngaqë parlamenti shpreson t'i mbyllë negociatat përpara zgjedhjeve të Majit të 2014-s, çka ka sjellë ngushtimin e madh të shtegut për konsultime.</p>
+				<h3>Ç’po ndodh në BE?</h3>
+				<p>Neelie Kroes, komisionerja për Axhendën Dixhitale, premtoi se do të mbronte asnjanësinë në rrjet. Megjithatë, gjatë pakë viteve të kaluara pozicioni i saj ka ndryshuar në mënyrë domethënëse në kah të kundërt. <a href="http://ec.europa.eu/information_society/newsroom/cf/dae/document.cfm?doc_id=2734">Propozimi i saj për një Akt Rregullator Tregu Unik Telekomesh</a> e ripohon këtë. Teksa e mirëpresim dëshirën për të shenjtëruar asnjanësinë e rrjetit në ligjet e vendeve të BE-së, propozimi nuk arrin të përmbushë premtimin për asnjanësi në rrjet, ngaqë përmban një numër të çarash problematike. Sidoqoftë, vetë teksti nuk është larg të saktit. Me përmirësimet e duhura, Bashkimi Europian do të mundte ta nguliste në legjislacion asnjanësinë e rrjetit. Propozimi tani është në duart e parlamentit dhe do të shqyrtohet nga disa komisione, me atë të Industrisë, Kërkimeve dhe Energjisë (ITRE) si i ngarkuari me dosjen. Modifikimet e propozuara në disa komisione për fat të keq i kanë përkeqësuar problemet në propozimin e Komisionit. Për më tepër, para legjislacionit ka një plan kohor shumë strikt, ngaqë parlamenti shpreson t’i mbyllë negociatat përpara zgjedhjeve të Majit të 2014-s, çka ka sjellë ngushtimin e madh të shtegut për konsultime.</p>
 					
 				<h3 id="arguments">Argumente</h3>
 				<h4>Shërbime të Specializuara</h4>
 				<p>Kompanitë e shërbimeve Internet, me jo pak të drejtë, pretendojnë të drejtën për të ofruar shërbime rrjeti të specializuara – fjala vjen, video HD - me shpejtësi të garantuar për zbatime industriale të përpikta. Për sa kohë që këto shërbime xhirohen veçmas nga interneti dhe nuk pleksen me cilësinë e internetit, kjo pa dyshim që nuk përbën problem.</p>
 				<p>Deri sot, Akti Rregullator i propozuar nuk ofron një përkufizim të qartë të shërbimeve të specializuara. Do të lejonte, pra, mundësinë e interpretimit si “shërbim i specializuar” të çfarëdo lloji shërbimi në linjë. Kjo do të shpinte në krijimin e një interneti me dy shpejtësi, ku disa shërbime do të kishin përparësi, teksa të tjerët do të nguceshin në korsinë e ngadaltë. Për pasojë, kjo do të kufizonte lirinë e komunikimeve, si dhe mundësitë dhe shtysat për risi. (Neni 2.15)</p>
-				<p><b>Shembull:</b> Mjaft operatorë të telefonisë celulare ofrojnë tashmë përdorim të pakufizuar të Facebook-ut, ndërkohë që gjithçka tjetër i nënshtrohet pagesës së bazuar në vëllimin e të dhënave të shkarkuara. Nëse përkufizimi i “shërbimit të specializuar” lejon këtë lloj oferte, ai do t'ua kufizojë konkurrentëve potencialë tregun e mundshëm, duke kufizuar kështu, tek e fundit, mundësitë e zgjedhjes dhe risitë.</p>
+				<p><b>Shembull:</b> Mjaft operatorë të telefonisë celulare ofrojnë tashmë përdorim të pakufizuar të Facebook-ut, ndërkohë që gjithçka tjetër i nënshtrohet pagesës së bazuar në vëllimin e të dhënave të shkarkuara. Nëse përkufizimi i “shërbimit të specializuar” lejon këtë lloj oferte, ai do t’ua kufizojë konkurrentëve potencialë tregun e mundshëm, duke kufizuar kështu, tek e fundit, mundësitë e zgjedhjes dhe risitë.</p>
 				<p><b>Ajo çka na duhet</b> është një qartësim që të sigurojë se “shërbimi” në fjalë nuk është identik, për nga funksioni, me një shërbim në linjë, dhe se ai ofrohet në një rrjet që është krejtësisht i veçuar prej internetit publik. Përkufizimi i Entit të Rregullatorëve Europianë (BEREC) thotë se shërbime të tilla duhet të jenë të ndara nga interneti publik i përpjekjes më të mirë dhe se duhet të ofrohen vetëm brenda rrjetit të europian të ofruesve të komunikacioneve elektronike.</p>
         <h4>“Liria” e përdoruesve të thjeshtë</h4>
-				<p>Teksti i propozuar nga Komisioni Europian do t'u jepte përdoruesve “lirinë” e zgjedhjes së një prej shërbimeve diskriminuese. Kjo “liri” në analizë të fundit do të jetë negative për përdoruesit e internetit dhe negative për mjedisin më të gjerë të risive në linjë (Neni 23).</p>
-				<p><b>Shembull:</b> Është parë se vetëm konsumatorët britanikë paguajnë përafërsisht 5 miliardë stërlina në vit më shumë, falë “lirisë” së tyre për të zgjedhur mes një numri të madh ofertash të ngatërruara shërbimesh.</p>
+				<p>Teksti i propozuar nga Komisioni Europian do t’u jepte përdoruesve “lirinë” e zgjedhjes së një prej shërbimeve diskriminuese. Kjo “liri” në analizë të fundit do të jetë negative për përdoruesit e internetit dhe negative për mjedisin më të gjerë të risive në linjë (Neni 23).</p>
+				<p><b>Shembull:</b> Është parë se vetëm konsumatorët britanikë paguajnë përafërsisht 5 miliardë sterlina në vit më shumë, falë “lirisë” së tyre për të zgjedhur mes një numri të madh ofertash të ngatërruara shërbimesh.</p>
 				<p><b>Ajo çka na duhet</b> është zëvendësimi i “duhet të jetë i lirë” me “gëzon të drejtën e” dhe të sigurohet se teksti nuk lejon ofrim shërbimesh diskriminuese nga operatorët e shërbimeve internet.</p>
 
 				<h4>“Për parandalimin ose pengimin e krimeve serioze”</h4>
-				<p>Lejimi i përdorimit të “masave të arsyeshme të administrimit të trafikut” për “parandalimin ose pengimin e krimeve serioze” do t'u bëjë të mundur kompanive të internetit të fusin hundët në komunikimet në linjë, pa një bazë ligjore apo vendim gjykate. Kjo do t' jepte ISP-ve forcën zbatuese të autoriteve ligjore, jashtë fushës së mbuluar nga ligji, çka është shkelje e nenit 52 të Kartës së të Drejtave Themelore të BE-së (Neni 23.5).</p>
+				<p>Lejimi i përdorimit të “masave të arsyeshme të administrimit të trafikut” për “parandalimin ose pengimin e krimeve serioze” do t’u bëjë të mundur kompanive të internetit të fusin hundët në komunikimet në linjë, pa një bazë ligjore apo vendim gjykate. Kjo do t’i jepte ISP-ve forcën zbatuese të autoriteteve ligjore, jashtë fushës së mbuluar nga ligji, çka është shkelje e nenit 52 të Kartës së të Drejtave Themelore të BE-së (Neni 23.5).</p>
 
 
-         <p><b>Shembull:</b> Në Mbretërinë e Bashkuar, për shembull, shihen tashmë masa parandalese për individë, të ndërmarra vullnetarisht nga ISP-ra, që shpien në bllokimin e paligjshëm të një numri shërbimesh të ligjshme në linjë. Në 2012-n, kjo solli bllokimin aksidental të sajtit web të grupit frëng të të drejtave civile, La Quadrature du Net.</p>
+         <p><b>Shembull:</b> Në Mbretërinë e Bashkuar, për shembull, shihen tashmë masa parandaluese për individë, të ndërmarra vullnetarisht nga ISP-ra, që shpien në bllokimin e paligjshëm të një numri shërbimesh të ligjshme në linjë. Në 2012-n, kjo solli bllokimin aksidental të sajtit të grupit frëng të të drejtave civile, La Quadrature du Net.</p>
 				<p><b>Çka na duhet</b> është heqja e përjashtimeve të rrezikshme në raste pleksjesh arbitrare të administrimit të arsyeshëm të trafikut me rrjedha trafiku të komunikimeve.</p>
 
  				<p>Për më tepër, lexoni analizën dhe propozimet tona mbi përmirësimin e Aktit Rregullator të propozuar:
@@ -314,7 +314,7 @@
 					
 					<h3>Kritika të famshme</h3>
 					<p>Akti Rregullator i propozuar është kritikuar nga mjaft institucione dhe individë të ndryshëm. Që përpara se drafti të bëhej i njohur publikisht, një pjesë e <a href="http://edri.org/NN-negativeopinions/">Komisionit Europian pat kritikuar një tjetër</a>, ngaqë e konsideronin propozimin si një kërcënim ndaj asnjanësisë në rrjet dhe ndaj të drejtave themelore.</p>
-		  
+		 
 					<p>Një kritikues tjetër i zëshëm është <a href="http://berec.europa.eu/eng/document_register/subject_matter/berec/opinions/?doc=2922">Enti i Rregullatorëve Europianë të Komunikimit Elektronik</a> (BEREC). Ky grup i pavarur ekspertize i rregullatorëve kombëtarë ndihmoi mjaft në diskutimet faktike mbi asnjanësinë në rrjet dhe <a href="http://berec.europa.eu/eng/document_register/subject_matter/berec/regulatory_best_practices/guidelines/1101-berec-guidelines-for-quality-of-service-in-the-scope-of-net-neutrality">paraqiti mjaft përkufizime të dobishme</a> (p.sh. për shërbimet e specializuara). Për më tepër, BEREC furnizoi të dhëna statistike të cilat tregonin se <a href="https://unsernetz.at/links/berec-eu-violations/">gjysma e popullsisë së Europës është tashmë e prekur nga shkelje të asnjanësisë së rrjetit në sektorin e celularit</a>. <a href="http://europa.eu/rapid/press-release_EDPS-13-10_en.htm">Mbikëqyrësi Europian i Mbrojtjes së të Dhënave</a> tërheq vëmendjen gjithashtu për të çarat në aplikimin e asnjanësisë në rrjet dhe thekson rrezikun për privatësinë e të dhënave në situatën e re ligjore.</p>
 
 					<div class="moaromg">
@@ -334,8 +334,8 @@
 		<div class=contentwidth>
 			<div class=indentarea2>
 
-				<h3>Si t'i telefononi eurodeputetit tuaj</h3>
-				<p><b>Hidhuni në veprim tani për t'u kërkuar përfaqësuesve tuaj të mbrojnë të drejtat dhe liritë tuaja. Mënyra më e mirë për ta bërë këtë është t'u telefonohet Anëtarëve të Parlamentit Europian (APE). Por mund t'u dërgoni edhe faks, letër ose e-mail - ju japim krejt informacionin, dhe telefonatat për ta janë falas.</b></p>
+				<h3>Si t’i telefononi eurodeputetit tuaj</h3>
+				<p><b>Hidhuni në veprim tani për t’u kërkuar përfaqësuesve tuaj të mbrojnë të drejtat dhe liritë tuaja. Mënyra më e mirë për ta bërë këtë është t’u telefonohet Anëtarëve të Parlamentit Europian (APE). Por mund t’u dërgoni edhe faks, letër ose e-mail - ju japim krejt informacionin, dhe telefonatat për ta janë falas.</b></p>
 
 				<h4>Këshillë e përgjithshme</h4>
 
@@ -344,11 +344,11 @@
 					<li>Shumicën e rasteve, do të bisedoni me një ndihmës të deputetit, dhe jo drejtpërdrejt me një eurodeputet. Nuk ka problem: hyni në bashkëbisedim. Ndihmësit luajnë rol të rëndësishëm në përcaktimin e qëndrimeve të një eurodeputeti.</li>
 					<li>Nëse mbin një pyetje për të cilën nuk keni përgjigje, mos bini pre e panikut. Nuk pritet që ju të jeni një ekspert, por vetëm një shtetas me një shqetësim. I thoni eurodeputetit se do të kërkoni për një përgjigje dhe do të lidheni sërish me të, me më tepër informacion, dhe ejani e na pyesni ne.</li>
 					<li>Nëse ende jeni i pasigurt me argumentet, mos u dorëzoni. Pyesni se cili është qëndrimi i eurodeputetit lidhur me subjektin, dhe pyesni se cilat janë argumentet e tij.</li>
-					<li>Gjatë një thirrjeje telefonike mos ngurroni të ofroni telefonata të tjera me më tepër informacion, takim me eurodeputetin, dërgim dokumentesh, referencash, etj. Ndonjëherë, ndihmësit parlamentarë mund t'ju kërkojnë të dërgoni një e-mail. Mos ngurroni t'u telefononi sërish për të parë nëse e lexuan dhe se ç'mendojnë për të.</li>
+					<li>Gjatë një thirrjeje telefonike mos ngurroni të ofroni telefonata të tjera me më tepër informacion, takim me eurodeputetin, dërgim dokumentesh, referencash, etj. Ndonjëherë, ndihmësit parlamentarë mund t’ju kërkojnë të dërgoni një e-mail. Mos ngurroni t’u telefononi sërish për të parë nëse e lexuan dhe se ç’mendojnë për të.</li>
 				</ul>
 
 				<h4>Telefonatë</h4>
-				<p>Mënyra më e mirë për të shpënë mesazhin tuaj te një eurodeputet është të <b>paraqisni argumentet tuaja gojarisht</b>. Në këtë mënyrë, mund t'ia përshtatni fjalën tuaj përgjigjeve të tij, dhe të shprehni shqetësimin tuaj të madh lidhur me subjektin për të cilin po telefononi. Eurodeputetët nuk marrin shumë telefonata nga qytetarët, ndaj janë veçanërisht të ndjeshëm ndaj tyre.</p>
+				<p>Mënyra më e mirë për të shpënë mesazhin tuaj te një eurodeputet është të <b>paraqisni argumentet tuaja gojarisht</b>. Në këtë mënyrë, mund t’ia përshtatni fjalën tuaj përgjigjeve të tij, dhe të shprehni shqetësimin tuaj të madh lidhur me subjektin për të cilin po telefononi. Eurodeputetët nuk marrin shumë telefonata nga qytetarët, ndaj janë veçanërisht të ndjeshëm ndaj tyre.</p>
 
 				<b>Përgjithësisht, bashkëbisedimi ngjan me këtë:</b>
 				
@@ -363,7 +363,7 @@
 				<p>
 					<div class="ava-assistant">Asistenti</div> 
 					<div class="bubble-assistant">
-						Znj/Z eurodeputete/eurodeputet, jam asistenti i tij/saj. Si mund t'ju ndihmoj?
+						Znj/Z eurodeputete/eurodeputet, jam asistenti i tij/saj. Si mund t’ju ndihmoj?
 					</div>
 				</p>
 				<div class=clr></div>
@@ -412,7 +412,7 @@
 				<p>
 					<div class="ava-you">Ju</div> 
 					<div class="bubble-you">
-					Shumë faleminderit që më dëgjuat. Nëse dëshironi, mund t'ju dërgoj dokumente për referencë. Do t'ju telefonoj prapë së afërmi që të mësoj se çfarë mendon ajo/ai. Ditën e mirë.
+					Shumë faleminderit që më dëgjuat. Nëse dëshironi, mund t’ju dërgoj dokumente për referencë. Do t’ju telefonoj prapë së afërmi që të mësoj se çfarë mendon ajo/ai. Ditën e mirë.
 					</div>
 				</p>
 				<div class=clr></div>
@@ -421,7 +421,7 @@
 
 				<h4>Postë</h4>
 				<p>Nëse nuk ju vjen ndoresh me telefonat, mundet gjithashtu <b>të lidheni me eurodeputetin tuaj me email</b>. Adresat e tyre i gjeni te pjesa <a href="#act">e postës më sipër</a> ose te <a rel="nofollow" class="external text" href="http://memopol.lqdn.fr/">Memopol</a>.</p>
-				<p>Disa njerëz, ndonjëherë, propozojnë që t'u niset një email i përgjithshëm krejt eurodeputetëve (pra edhe atyre që nuk votojnë mbi subjektin në fjalë). Ne besojmë se email-e të tillë më shumë prishin, se sa ndreqin punë. Eurodeputetët dhe ndihmësit e tyre dinë si t'i përdorin filtrat për spam, njësoj si ju, dhe email-e të tillë përfundojnë shpejt e shpejt në dosjen e spamit. Email-et e përgjithshëm të lënë përshtypjen se nuk dëshironi të shpenzoni kohë për t'i hyrë më thellë temës, dhe nuk pasqyrojnë numrin e personave të përfshirë në të (një njeri i vetëm mund të dërgojë disa mesazhe). Më keq akoma, email-e të tillë shtojnë rrezikun që eurodeputetët të mos lexojnë mesazhet e personalizuar lidhur me të njëjtën çështje, duke i bërë përfundimisht dëm kauzës.</p>
+				<p>Disa njerëz, ndonjëherë, propozojnë që t’u niset një email i përgjithshëm krejt eurodeputetëve (pra edhe atyre që nuk votojnë mbi subjektin në fjalë). Ne besojmë se email-e të tillë më shumë prishin, se sa ndreqin punë. Eurodeputetët dhe ndihmësit e tyre dinë si t’i përdorin filtrat për spam, njësoj si ju, dhe email-e të tillë përfundojnë shpejt e shpejt në dosjen e spamit. Email-et e përgjithshëm të lënë përshtypjen se nuk dëshironi të shpenzoni kohë për t’i hyrë më thellë temës, dhe nuk pasqyrojnë numrin e personave të përfshirë në të (një njeri i vetëm mund të dërgojë disa mesazhe). Më keq akoma, email-e të tillë shtojnë rrezikun që eurodeputetët të mos lexojnë mesazhet e personalizuar lidhur me të njëjtën çështje, duke i bërë përfundimisht dëm kauzës.</p>
 				<p>Zgjidhja më e mirë është të dërgohen email-e të personalizuar, bazuar në mënyrën tuaj dhe në njohjen tuaj të çështjes dhe, nëse është e mundur, në përputhje me pozicionet e grupit politik të eurodeputetit në fjalë. (Mos harroni: nuk pret njeri që të jeni ekspert, por thjesht një shtetas me një shqetësim.)</p>
 				<center>
 				<iframe src="https://mediakit.laquadrature.net/embed/1174?size=medium&amp;onlyvideo" style="width:640px; height:360px; border: 0; overflow: hidden" scrolling="no" frameborder="0"></iframe>
@@ -446,17 +446,17 @@
 				<h3>Lidhuni me ne</h3>
 				<p>Me ne mund të lidheni duke përdorur <b><span class="mailcheat" locip="info" domip="savetheinternet.eu">info /at/ savetheinternet.eu</span></b></p>
 
-				<p><b>Keni një ide për përmirësimin e këtij sajti web? Shumë bukur, na duheni! </b> <br/>
-					Kodi i plotë burim i këtij sajti web gjendet në <a href="https://github.com/netzfreiheit/savetheinternet">github</a> dhe mund ta degëzoni, përmirësoni, ripërzieni dhe të na parashtroni ndryshimet tuaja.</p>
+				<p><b>Keni një ide për përmirësimin e këtij sajti? Shumë bukur, na duheni! </b> <br/>
+					Kodi i plotë burim i këtij sajti gjendet në <a href="https://github.com/netzfreiheit/savetheinternet">github</a> dhe mund ta degëzoni, përmirësoni, ripërzieni dhe të na parashtroni ndryshimet tuaja.</p>
 				<p>Diçka për të cilën kemi përherë nevojë është <b>ndihma me përkthimet</b>, nëse flisni një gjuhë që nuk e kemi mbuluar ende deri më sot, ju lutemi, lidhuni me ne.</p>
 
 				<h3>Interesim Nga Shtypi</h3>
-				<p>Ekipi ynë për median do të ishte i lumtur t'i përgjigjej krejt interesimit nga shtypi. Thjesht na dërgoni një e-mail te <b><span class="mailcheat" locip="press" domip="savetheinternet.eu">press /at/ savetheinternet.eu</span></b>.</p>
+				<p>Ekipi ynë për median do të ishte i lumtur t’i përgjigjej krejt interesimit nga shtypi. Thjesht na dërgoni një e-mail te <b><span class="mailcheat" locip="press" domip="savetheinternet.eu">press /at/ savetheinternet.eu</span></b>.</p>
 					<p>Ekspertë vendorë nga disa vende europiane janë të gatshëm për intervista. <br/>Material fotografik dhe grafik mund të gjeni <a href="/f/press/press-pics.zip">këtu</a> (arkiv zip). </p>
 
-				<h3>Na përkrahni me paraqitje në sajt web</h3>
+				<h3>Na përkrahni me paraqitje në sajt</h3>
 				<center>
-					Nëse keni një sajt web, shihni mundësinë e vendosjes së stemave tona:<br/>
+					Nëse keni një sajt, shihni mundësinë e vendosjes së stemave tona:<br/>
 					<a href="/banner.zip">
 						<p>Shkarkojeni paketën</p>
 						<img src="/f/press/pics/Full-Banner.png"/>


### PR DESCRIPTION
...'sajt' is a neologism in Albanian reserved only for 'web sites'

It needed a spell-checking, skipped somehow when it was first committed. Mainly to deal with proper apostrophe, and to clear a redundancy due to the use of word "web" in translation of things like "website" or "web site". "Sajt" is a neologism for sq. It refers only to web. There's no other things in Albanian you could define using 'sajt'. It has been used for over ten years now, without a real need for it.