### PR TITLE
Return Czech translation of "See the amendments" where it belongs

### DIFF
--- a/background/cs/index.html
+++ b/background/cs/index.html
@@ -77,7 +77,7 @@
                 Buď Rada po hlasování v Evropském parlamentu přijme dodatky nebo nastane další kolo vyjednávání v Dohadovacím výboru. Až se dohodne konečné znění, Sdružení evropských regulačních orgánů v oblasti elektronických komunikací (BEREC), bude pořádat konzultace, do kterých se může zapojit každý a které budou zohledněny při vytváření doporučení založených na legislativě přijaté v EU. Tato doporučení a legislativa budou závazná pro národní regulátory telekomunikačních společností, kteří určují pravidla pro telekomunikační společnosti ve všech 28 členských státech.
                 </p>
                 <div class="teaser" style="">
-                    <a href="http://www.europarl.europa.eu/plenary/en/report-details.html?reference=A8-0300-2015" alt="" target="_blank">See the amendments</a> (2-24)
+                    <a href="http://www.europarl.europa.eu/plenary/cs/report-details.html?reference=A8-0300-2015" alt="" target="_blank">Přečtěte si pozměňovací návrhy</a> (2-24)
                 </div>
                 
                 <a href="/img/NN_process_infographics.png"><img src="/img/NN_process_infographics.png" alt="vysvětlení dohadovacího výboru" width="100%"/></a>

--- a/cs/index.html
+++ b/cs/index.html
@@ -302,7 +302,7 @@
 		<div class="clr"></div>
 
 		<div class="teaser" style="">
-			<a href="http://www.europarl.europa.eu/plenary/en/report-details.html?reference=A8-0300-2015" alt="" target="_blank">See the amendments</a> (2-24)
+			<a href="http://www.europarl.europa.eu/plenary/cs/report-details.html?reference=A8-0300-2015" alt="" target="_blank">Přečtěte si pozměňovací návrhy</a> (2-24)
 		</div>
 
 	<div class="clr">&nbsp;</div>


### PR DESCRIPTION
The commented-out placeholder link was already translated correctly. You didn't need to revert it to English.